### PR TITLE
Add option to pass the blocked url to override route/path

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -96,6 +96,7 @@ class Configuration implements ConfigurationInterface
                     ->children()
                         ->booleanNode('abort')->defaultFalse()->end()
                         ->scalarNode('override')->defaultNull()->end()
+                        ->scalarNode('override_url_parameter_name')->defaultNull()->end()
                         ->booleanNode('log')->defaultFalse()->end()
                         ->arrayNode('whitelist')
                             ->prototype('scalar')->end()

--- a/DependencyInjection/NelmioSecurityExtension.php
+++ b/DependencyInjection/NelmioSecurityExtension.php
@@ -54,6 +54,7 @@ class NelmioSecurityExtension extends Extension
         if (!empty($config['external_redirects'])) {
             $loader->load('external_redirects.yml');
             $container->setParameter('nelmio_security.external_redirects.override', $config['external_redirects']['override']);
+            $container->setParameter('nelmio_security.external_redirects.overrideurlparametername', $config['external_redirects']['override_url_parameter_name']);
             $container->setParameter('nelmio_security.external_redirects.abort', $config['external_redirects']['abort']);
             if ($config['external_redirects']['whitelist']) {
                 $whitelist = array_map(function($el) {

--- a/Resources/config/external_redirects.yml
+++ b/Resources/config/external_redirects.yml
@@ -8,6 +8,7 @@ services:
         arguments:
             - %nelmio_security.external_redirects.abort%
             - %nelmio_security.external_redirects.override%
+            - %nelmio_security.external_redirects.overrideurlparametername%
             - %nelmio_security.external_redirects.whitelist%
             - @?logger
             - @?router


### PR DESCRIPTION
Introduce configuration parameter `override_url_parameter_name` to pass the blocked url to destination route / path as parameter.

In case `override` is a route `override_url_parameter_name` will be used as route parameter name otherwise as query string parameter name.

To pass the blocked url offers the opportunity to display the blocked url or create a clickable link, et cetera.
