### PR TITLE
Removed the error suppression in Encrypter

### DIFF
--- a/Encrypter.php
+++ b/Encrypter.php
@@ -22,8 +22,12 @@ class Encrypter
     {
         $this->secret = substr($secret, 0, 32);
         $this->algorithm = $algorithm;
+        
+        if (!function_exists('mcrypt_module_open')) {
+            throw new \RuntimeException('You need to install mcrypt if you want to encrypt your cookies.');
+        }
 
-        $this->module = mcrypt_module_open($this->algorithm, '', MCRYPT_MODE_CBC, '');
+        $this->module = @mcrypt_module_open($this->algorithm, '', MCRYPT_MODE_CBC, '');
         if ($this->module === false) {
             throw new \InvalidArgumentException(sprintf("The supplied encryption algorithm '%s' is not supported by this system.",
                 $this->algorithm));


### PR DESCRIPTION
If you don't have mcrypt installed enabling the Encrypted cookies feature will cause a blank screen. This is because the function calls to mcrypt_ are suppressed. 

Maybe it would be even better to do a check in the Configuration.php file to see if mcrypt is installed?
