### PR TITLE
Update framework.session.secure example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,7 +263,7 @@ and all other cookies your send for that matter. You can do the former using:
 
     framework:
         session:
-            secure: true
+            cookie_secure: true
 
 To keep a few URLs from being force-redirected to SSL you can define a whitelist of regular
 expressions:
@@ -310,7 +310,7 @@ it just yet, keep reading to the end.
 
     framework:
         session:
-            secure: true
+            cookie_secure: true
 
 If you use the remember-me functionality, you would also mark that one as secure:
 


### PR DESCRIPTION
Tiny docs tweak, option was changed to framework.session.cookie_secure in Symfony 2.1 ( https://github.com/symfony/symfony/blob/master/UPGRADE-2.1.md#frameworkbundle ). Might as well keep this in sync.
