### PR TITLE
Add configurable HSTS preloading

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -120,6 +120,7 @@ class Configuration implements ConfigurationInterface
                         ->booleanNode('enabled')->defaultTrue()->end()
                         ->scalarNode('hsts_max_age')->defaultNull()->end()
                         ->booleanNode('hsts_subdomains')->defaultFalse()->end()
+                        ->booleanNode('hsts_preload')->defaultFalse()->end()
                         ->arrayNode('whitelist')
                             ->prototype('scalar')->end()
                         ->end()

--- a/DependencyInjection/NelmioSecurityExtension.php
+++ b/DependencyInjection/NelmioSecurityExtension.php
@@ -112,6 +112,7 @@ class NelmioSecurityExtension extends Extension
             }
             $container->setParameter('nelmio_security.forced_ssl.hsts_max_age', $config['forced_ssl']['hsts_max_age']);
             $container->setParameter('nelmio_security.forced_ssl.hsts_subdomains', $config['forced_ssl']['hsts_subdomains']);
+            $container->setParameter('nelmio_security.forced_ssl.hsts_preload', $config['forced_ssl']['hsts_preload']);
             $container->setParameter('nelmio_security.forced_ssl.whitelist', $config['forced_ssl']['whitelist'] ?: array());
         }
     }

--- a/EventListener/ForcedSslListener.php
+++ b/EventListener/ForcedSslListener.php
@@ -22,12 +22,14 @@ class ForcedSslListener
 {
     private $hstsMaxAge;
     private $hstsSubdomains;
+    private $hstsPreload;
     private $whitelist;
 
-    public function __construct($hstsMaxAge, $hstsSubdomains, array $whitelist = array())
+    public function __construct($hstsMaxAge, $hstsSubdomains, $hstsPreload = false, array $whitelist = array())
     {
         $this->hstsMaxAge = $hstsMaxAge;
         $this->hstsSubdomains = $hstsSubdomains;
+        $this->hstsPreload = $hstsPreload;
         $this->whitelist = $whitelist ? '('.implode('|', $whitelist).')' : null;
     }
 
@@ -62,7 +64,10 @@ class ForcedSslListener
         $response = $e->getResponse();
 
         if (!$response->headers->has('Strict-Transport-Security')) {
-            $response->headers->set('Strict-Transport-Security', 'max-age='.$this->hstsMaxAge . ($this->hstsSubdomains ? '; includeSubDomains' : ''));
+            $header = 'max-age='.$this->hstsMaxAge;
+            $header .= ($this->hstsSubdomains ? '; includeSubDomains' : '');
+            $header .= ($this->hstsPreload ? '; preload' : '');
+            $response->headers->set('Strict-Transport-Security',  $header);
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -413,6 +413,22 @@ nelmio_security:
         hsts_subdomains: false
 ```
 
+You can also tell the browser to add your site to the list of known HSTS sites, by enabling
+`hsts_preload`. Once your site has appeared in the Chrome and Firefox preload lists, then new
+users who come to your site will already be redirected to https urls.
+
+```yaml
+nelmio_security:
+    forced_ssl:
+        hsts_max_age: 10886400 # 18 weeks
+        hsts_preload: true
+```
+
+Note: A value of at least 18 weeks is currently required by [Chrome](https://hstspreload.appspot.com)
+and [Firefox](https://blog.mozilla.org/security/2012/11/01/preloading-hsts/).
+
+You can speed up the inclusion process by submitting your site to the [HSTS Preload List](https://hstspreload.appspot.com).
+
 A small word of caution: While HSTS is great for security, it means that if the browser
 can not establish your SSL certificate is valid, it will not allow the user to query your site.
 That just means you should be careful and renew your certificate in due time.

--- a/Resources/config/forced_ssl.yml
+++ b/Resources/config/forced_ssl.yml
@@ -4,6 +4,7 @@ services:
         arguments:
             - %nelmio_security.forced_ssl.hsts_max_age%
             - %nelmio_security.forced_ssl.hsts_subdomains%
+            - %nelmio_security.forced_ssl.hsts_preload%
             - %nelmio_security.forced_ssl.whitelist%
         tags:
             - { name: kernel.event_listener, event: kernel.request, method: onKernelRequest, priority: 30000 }

--- a/Tests/Listener/ForcedSslListenerTest.php
+++ b/Tests/Listener/ForcedSslListenerTest.php
@@ -31,9 +31,9 @@ class ForcedSslListenerTest extends \PHPUnit_Framework_TestCase
     /**
      * @dataProvider provideHstsHeaders
      */
-    public function testHstsHeaders($hstsMaxAge, $hstsSubdomains, $result)
+    public function testHstsHeaders($hstsMaxAge, $hstsSubdomains, $hstsPreload, $result)
     {
-        $listener = new ForcedSslListener($hstsMaxAge, $hstsSubdomains);
+        $listener = new ForcedSslListener($hstsMaxAge, $hstsSubdomains, $hstsPreload);
 
         $response = $this->callListenerResp($listener, '/', true);
         $this->assertSame($result, $response->headers->get('Strict-Transport-Security'));
@@ -42,10 +42,12 @@ class ForcedSslListenerTest extends \PHPUnit_Framework_TestCase
     public function provideHstsHeaders()
     {
         return array(
-            array(60, true, 'max-age=60; includeSubDomains'),
-            array(60, false, 'max-age=60'),
-            array(3600, true, 'max-age=3600; includeSubDomains'),
-            array(3600, false, 'max-age=3600'),
+            array(60, true, false, 'max-age=60; includeSubDomains'),
+            array(60, false, false, 'max-age=60'),
+            array(3600, true, false, 'max-age=3600; includeSubDomains'),
+            array(3600, false, false, 'max-age=3600'),
+            array(3600, true, true, 'max-age=3600; includeSubDomains; preload'),
+            array(3600, false, true, 'max-age=3600; preload'),
         );
     }
 
@@ -59,7 +61,7 @@ class ForcedSslListenerTest extends \PHPUnit_Framework_TestCase
 
     public function testForcedSslSkipsWhitelisted()
     {
-        $listener = new ForcedSslListener(60, true, array('^/foo/', 'bar'));
+        $listener = new ForcedSslListener(60, true, false, array('^/foo/', 'bar'));
 
         $response = $this->callListenerReq($listener, '/foo/lala', true);
         $this->assertSame(null, $response);


### PR DESCRIPTION
Quoting from the README addition:

You can also tell the browser to add your site to the list of known HSTS sites, by enabling
`hsts_preload`. Once your site has appeared in the Chrome and Firefox preload lists, then new
users who come to your site will already be redirected to https urls.