### PR TITLE
use assertArrayHasKey in ConfigurationTest

### DIFF
--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -24,7 +24,7 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
         $config = $this->processYamlConfiguration(
             "csp: ~"
         );
-        $this->assertContains('report_only', $config['csp']);
+        $this->assertArrayHasKey('report_only', $config['csp']);
         $this->assertFalse($config['csp']['report_only'], 'default value for report_only config should be false');
     }
 


### PR DESCRIPTION
this seems more accurate, and fixes a bug when trying to remove
the compat_headers option.

When i tried removing the compat_headers option i ended up with:

1) Nelmio\SecurityBundle\Tests\DependencyInjection\ConfigurationTest::testCspReportOnlyDefaultIsFalse
Failed asserting that an array contains 'report_only'.

which seems like a totally unrelated issue.