### PR TITLE
Remove CSP compat_headers option

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -161,9 +161,6 @@ class Configuration implements ConfigurationInterface
             ->addDirectives($node->children())
                 ->scalarNode('report_uri')->defaultValue('')->end()
                 ->booleanNode('report_only')->end()
-                // leaving this enabled can cause issues with older iOS (5.x) versions
-                // and possibly other early CSP implementations
-                ->booleanNode('compat_headers')->defaultValue(true)->end()
                 ->scalarNode('report_logger_service')->defaultValue('logger')->end()
                 ->append($this->addReportOrEnforceNode('report'))
                 ->append($this->addReportOrEnforceNode('enforce'))

--- a/EventListener/ContentSecurityPolicyListener.php
+++ b/EventListener/ContentSecurityPolicyListener.php
@@ -12,13 +12,11 @@ class ContentSecurityPolicyListener implements EventSubscriberInterface
 {
     protected $report;
     protected $enforce;
-    protected $compatHeaders;
 
-    public function __construct(DirectiveSet $report, DirectiveSet $enforce, $compatHeaders = true)
+    public function __construct(DirectiveSet $report, DirectiveSet $enforce)
     {
         $this->report = $report;
         $this->enforce = $enforce;
-        $this->compatHeaders = $compatHeaders;
     }
 
     public function onKernelResponse(FilterResponseEvent $e)
@@ -28,11 +26,11 @@ class ContentSecurityPolicyListener implements EventSubscriberInterface
         }
 
         $response = $e->getResponse();
-        $response->headers->add($this->buildHeaders($this->report, true, $this->compatHeaders));
-        $response->headers->add($this->buildHeaders($this->enforce, false, $this->compatHeaders));
+        $response->headers->add($this->buildHeaders($this->report, true));
+        $response->headers->add($this->buildHeaders($this->enforce, false));
     }
 
-    private function buildHeaders(DirectiveSet $directiveSet, $reportOnly, $compatHeaders)
+    private function buildHeaders(DirectiveSet $directiveSet, $reportOnly)
     {
         $headerValue = $directiveSet->buildHeaderValue();
         if (!$headerValue) {
@@ -46,11 +44,6 @@ class ContentSecurityPolicyListener implements EventSubscriberInterface
         $headers = array(
             $hn('Content-Security-Policy') => $headerValue
         );
-
-        if ($compatHeaders) {
-            $headers[$hn('X-Content-Security-Policy')] = $headerValue;
-            $headers[$hn('X-Webkit-CSP')] = $headerValue;
-        }
 
         return $headers;
     }
@@ -83,6 +76,6 @@ class ContentSecurityPolicyListener implements EventSubscriberInterface
             }
         }
 
-        return new self($report, $enforce, !!$config['compat_headers']);
+        return new self($report, $enforce);
     }
 }

--- a/README.md
+++ b/README.md
@@ -192,17 +192,6 @@ nelmio_security:
         report_logger_service: monolog.logger.security
 ```
 
-(Optional) Disable *compat_headers* to avoid sending X-Content-Security-Policy
-(IE10, IE11, Firefox < 23) and X-Webkit-CSP (Chrome < 25, Safari < 7). This will
-mean those browsers get no more CSP instructions, but it can help if you are
-experience issues with old iOS 5.0 or 5.1 versions that had buggy CSP implementations.
-
-```yaml
-nelmio_security:
-    csp:
-        compat_headers: false
-```
-
 ### **Signed Cookies**:
 
 Ideally you should explicitly specify which cookies to sign. The reason for this is simple.

--- a/Tests/Listener/ContentSecurityPolicyListenerTest.php
+++ b/Tests/Listener/ContentSecurityPolicyListenerTest.php
@@ -210,41 +210,6 @@ class ContentSecurityPolicyListenerTest extends \PHPUnit_Framework_TestCase
             $header,
             'Response should contain only the default as the others are equivalent'
         );
-
-        $this->assertEquals(
-            $response->headers->get('Content-Security-Policy'),
-            $response->headers->get('X-Webkit-CSP'),
-            'Response should contain vendor specific X-Webkit-CSP header'
-        );
-    }
-
-    public function testVendorPrefixes()
-    {
-        $spec     = "example.org";
-        $listener = $this->buildSimpleListener(array(
-            'default-src' => $spec,
-            'script-src' => $spec,
-            'object-src' => $spec,
-            'style-src' => $spec,
-            'img-src' => $spec,
-            'media-src' => $spec,
-            'frame-src' => $spec,
-            'font-src' => $spec,
-            'connect-src' => $spec
-        ));
-        $response = $this->callListener($listener, '/', true);
-
-        $this->assertEquals(
-            $response->headers->get('Content-Security-Policy'),
-            $response->headers->get('X-Content-Security-Policy'),
-            'Response should contain non-standard X-Content-Security-Policy header'
-        );
-
-        $this->assertEquals(
-            $response->headers->get('Content-Security-Policy'),
-            $response->headers->get('X-Webkit-CSP'),
-            'Response should contain vendor specific X-Webkit-CSP header'
-        );
     }
 
     public function testReportOnly()
@@ -283,8 +248,6 @@ class ContentSecurityPolicyListenerTest extends \PHPUnit_Framework_TestCase
         ), false, false);
         $response = $this->callListener($listener, '/', true);
 
-        $this->assertNull($response->headers->get('X-Webkit-CSP'));
-        $this->assertNull($response->headers->get('X-Content-Security-Policy'));
         $this->assertNotNull($response->headers->get('Content-Security-Policy'));
     }
 


### PR DESCRIPTION
An alternative to https://github.com/nelmio/NelmioSecurityBundle/pull/46

From my reading, it doesn't seem like this option provides much value anymore.
Most people have upgraded to browsers that support the standard implementation now.

This PR also requires https://github.com/nelmio/NelmioSecurityBundle/pull/45
for the tests to pass.