### PR TITLE
Remove support for X-Webkit-CSP

### DIFF
--- a/EventListener/ContentSecurityPolicyListener.php
+++ b/EventListener/ContentSecurityPolicyListener.php
@@ -49,7 +49,6 @@ class ContentSecurityPolicyListener implements EventSubscriberInterface
 
         if ($compatHeaders) {
             $headers[$hn('X-Content-Security-Policy')] = $headerValue;
-            $headers[$hn('X-Webkit-CSP')] = $headerValue;
         }
 
         return $headers;

--- a/README.md
+++ b/README.md
@@ -193,9 +193,7 @@ nelmio_security:
 ```
 
 (Optional) Disable *compat_headers* to avoid sending X-Content-Security-Policy
-(IE10, IE11, Firefox < 23) and X-Webkit-CSP (Chrome < 25, Safari < 7). This will
-mean those browsers get no more CSP instructions, but it can help if you are
-experience issues with old iOS 5.0 or 5.1 versions that had buggy CSP implementations.
+(IE10, IE11, Firefox < 23). This will mean those browsers get no CSP instructions.
 
 ```yaml
 nelmio_security:

--- a/Tests/Listener/ContentSecurityPolicyListenerTest.php
+++ b/Tests/Listener/ContentSecurityPolicyListenerTest.php
@@ -210,12 +210,6 @@ class ContentSecurityPolicyListenerTest extends \PHPUnit_Framework_TestCase
             $header,
             'Response should contain only the default as the others are equivalent'
         );
-
-        $this->assertEquals(
-            $response->headers->get('Content-Security-Policy'),
-            $response->headers->get('X-Webkit-CSP'),
-            'Response should contain vendor specific X-Webkit-CSP header'
-        );
     }
 
     public function testVendorPrefixes()
@@ -238,12 +232,6 @@ class ContentSecurityPolicyListenerTest extends \PHPUnit_Framework_TestCase
             $response->headers->get('Content-Security-Policy'),
             $response->headers->get('X-Content-Security-Policy'),
             'Response should contain non-standard X-Content-Security-Policy header'
-        );
-
-        $this->assertEquals(
-            $response->headers->get('Content-Security-Policy'),
-            $response->headers->get('X-Webkit-CSP'),
-            'Response should contain vendor specific X-Webkit-CSP header'
         );
     }
 
@@ -283,7 +271,6 @@ class ContentSecurityPolicyListenerTest extends \PHPUnit_Framework_TestCase
         ), false, false);
         $response = $this->callListener($listener, '/', true);
 
-        $this->assertNull($response->headers->get('X-Webkit-CSP'));
         $this->assertNull($response->headers->get('X-Content-Security-Policy'));
         $this->assertNotNull($response->headers->get('Content-Security-Policy'));
     }


### PR DESCRIPTION
I think that there has been enough time for this header to no longer
be necessary.

Let me know if you disagree.