### PR TITLE
Remove unused buildHeaderName

### DIFF
--- a/EventListener/ContentSecurityPolicyListener.php
+++ b/EventListener/ContentSecurityPolicyListener.php
@@ -54,11 +54,6 @@ class ContentSecurityPolicyListener implements EventSubscriberInterface
         return $headers;
     }
 
-    private function buildHeaderName($baseName, $reportOnly)
-    {
-        return $baseName . ($reportOnly ? '-Report-Only' : '');
-    }
-
     public static function getSubscribedEvents()
     {
         return array(KernelEvents::RESPONSE => 'onKernelResponse');


### PR DESCRIPTION
It's a private method, so no BC issues