### PR TITLE
add support for host-based CSP settings

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -161,6 +161,7 @@ class Configuration implements ConfigurationInterface
             ->addDirectives($node->children())
                 ->scalarNode('report_uri')->defaultValue('')->end()
                 ->booleanNode('report_only')->end()
+                ->arrayNode('hosts')->prototype('scalar')->end()->defaultValue(array())->end()
                 // leaving this enabled can cause issues with older iOS (5.x) versions
                 // and possibly other early CSP implementations
                 ->booleanNode('compat_headers')->defaultValue(true)->end()

--- a/EventListener/ContentSecurityPolicyListener.php
+++ b/EventListener/ContentSecurityPolicyListener.php
@@ -13,12 +13,14 @@ class ContentSecurityPolicyListener implements EventSubscriberInterface
     protected $report;
     protected $enforce;
     protected $compatHeaders;
+    protected $hosts;
 
-    public function __construct(DirectiveSet $report, DirectiveSet $enforce, $compatHeaders = true)
+    public function __construct(DirectiveSet $report, DirectiveSet $enforce, $compatHeaders = true, array $hosts = array())
     {
         $this->report = $report;
         $this->enforce = $enforce;
         $this->compatHeaders = $compatHeaders;
+        $this->hosts = $hosts;
     }
 
     public function onKernelResponse(FilterResponseEvent $e)
@@ -28,8 +30,10 @@ class ContentSecurityPolicyListener implements EventSubscriberInterface
         }
 
         $response = $e->getResponse();
-        $response->headers->add($this->buildHeaders($this->report, true, $this->compatHeaders));
-        $response->headers->add($this->buildHeaders($this->enforce, false, $this->compatHeaders));
+        if (empty($this->hosts) || (in_array($e->getRequest()->server->get('HTTP_HOST'), $this->hosts))) {
+            $response->headers->add($this->buildHeaders($this->report, true, $this->compatHeaders));
+            $response->headers->add($this->buildHeaders($this->enforce, false, $this->compatHeaders));
+        }
     }
 
     private function buildHeaders(DirectiveSet $directiveSet, $reportOnly, $compatHeaders)
@@ -77,6 +81,6 @@ class ContentSecurityPolicyListener implements EventSubscriberInterface
             }
         }
 
-        return new self($report, $enforce, !!$config['compat_headers']);
+        return new self($report, $enforce, !!$config['compat_headers'], $config['hosts']);
     }
 }

--- a/EventListener/ContentSecurityPolicyListener.php
+++ b/EventListener/ContentSecurityPolicyListener.php
@@ -30,7 +30,7 @@ class ContentSecurityPolicyListener implements EventSubscriberInterface
         }
 
         $response = $e->getResponse();
-        if (empty($this->hosts) || (in_array($e->getRequest()->server->get('HTTP_HOST'), $this->hosts))) {
+        if (empty($this->hosts) || in_array($e->getRequest()->server->get('HTTP_HOST'), $this->hosts)) {
             $response->headers->add($this->buildHeaders($this->report, true, $this->compatHeaders));
             $response->headers->add($this->buildHeaders($this->enforce, false, $this->compatHeaders));
         }


### PR DESCRIPTION
In a multi-domain use-case where the CSP should be enforced only on a subset of all domains handled by a single symfony2 installation is sometimes unwanted to have CSP running on all domains.
As an example if an application runs on app.example.net and there is api.example.net for oauth with nelmio apidoc bundle, the apidoc bundle would be broken due inline JS.
This pull requests makes it possible to take out api.example.net from CSP restriction