### PR TITLE
 Add HTTP response's content-type restriction for Clickjacking and CSP headers.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 1.8.0 (2015-xx-xx)
+
+  * Add HTTP response's content-type restriction for Clickjacking and CSP headers.
+
 ### 1.7.0 (2015-05-10)
 
   * Added a `Nelmio\SecurityBundle\ExternalRedirect\TargetValidator` interface to implement custom rules for the external_redirects feature. You can override the `nelmio_security.external_redirect.target_validator` service to change the default.

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -162,6 +162,7 @@ class Configuration implements ConfigurationInterface
                 ->scalarNode('report_uri')->defaultValue('')->end()
                 ->booleanNode('report_only')->end()
                 ->arrayNode('hosts')->prototype('scalar')->end()->defaultValue(array())->end()
+                ->arrayNode('content_types')->prototype('scalar')->end()->defaultValue(array())->end()
                 // leaving this enabled can cause issues with older iOS (5.x) versions
                 // and possibly other early CSP implementations
                 ->booleanNode('compat_headers')->defaultValue(true)->end()

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -86,6 +86,7 @@ class Configuration implements ConfigurationInterface
                             ->end()
                             ->defaultValue(array('^/.*' => array('header' => 'DENY')))
                         ->end()
+                        ->arrayNode('content_types')->prototype('scalar')->end()->defaultValue(array())->end()
                     ->end()
                 ->end()
 

--- a/DependencyInjection/NelmioSecurityExtension.php
+++ b/DependencyInjection/NelmioSecurityExtension.php
@@ -52,6 +52,7 @@ class NelmioSecurityExtension extends Extension
         if (!empty($config['clickjacking'])) {
             $loader->load('clickjacking.yml');
             $container->setParameter('nelmio_security.clickjacking.paths', $config['clickjacking']['paths']);
+            $container->setParameter('nelmio_security.clickjacking.content_types', $config['clickjacking']['content_types']);
         }
 
         if (!empty($config['csp'])) {

--- a/EventListener/AbstractContentTypeRestrictableListener.php
+++ b/EventListener/AbstractContentTypeRestrictableListener.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the Nelmio SecurityBundle.
+ *
+ * (c) Nelmio <hello@nelm.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Nelmio\SecurityBundle\EventListener;
 
 use Symfony\Component\HttpFoundation\Response;

--- a/EventListener/AbstractContentTypeRestrictableListener.php
+++ b/EventListener/AbstractContentTypeRestrictableListener.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Nelmio\SecurityBundle\EventListener;
+
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+abstract class AbstractContentTypeRestrictableListener implements EventSubscriberInterface
+{
+    protected $contentTypes;
+
+    protected function isContentTypeValid(Response $response)
+    {
+        if (empty($this->contentTypes)) {
+            return true;
+        }
+
+        $contentTypeData = explode(';', $response->headers->get('content-type'), 2);
+
+        return in_array(trim($contentTypeData[0]), $this->contentTypes, true);
+    }
+}

--- a/EventListener/ClickjackingListener.php
+++ b/EventListener/ClickjackingListener.php
@@ -13,19 +13,30 @@ namespace Nelmio\SecurityBundle\EventListener;
 
 use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\HttpKernel\KernelEvents;
 
-class ClickjackingListener
+class ClickjackingListener extends AbstractContentTypeRestrictableListener
 {
     private $paths;
 
-    public function __construct($paths)
+    public function __construct($paths, $contentTypes)
     {
         $this->paths = $paths;
+        $this->contentTypes = $contentTypes;
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return array(KernelEvents::RESPONSE => 'onKernelResponse');
     }
 
     public function onKernelResponse(FilterResponseEvent $e)
     {
         if (HttpKernelInterface::MASTER_REQUEST !== $e->getRequestType()) {
+            return;
+        }
+
+        if (!$this->isContentTypeValid($e->getResponse())) {
             return;
         }
 

--- a/EventListener/ClickjackingListener.php
+++ b/EventListener/ClickjackingListener.php
@@ -19,7 +19,7 @@ class ClickjackingListener extends AbstractContentTypeRestrictableListener
 {
     private $paths;
 
-    public function __construct($paths, $contentTypes)
+    public function __construct($paths, $contentTypes = array())
     {
         $this->paths = $paths;
         $this->contentTypes = $contentTypes;

--- a/EventListener/ContentSecurityPolicyListener.php
+++ b/EventListener/ContentSecurityPolicyListener.php
@@ -2,20 +2,17 @@
 
 namespace Nelmio\SecurityBundle\EventListener;
 
-use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
-use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\KernelEvents;
 use Nelmio\SecurityBundle\ContentSecurityPolicy\DirectiveSet;
 
-class ContentSecurityPolicyListener implements EventSubscriberInterface
+class ContentSecurityPolicyListener extends AbstractContentTypeRestrictableListener
 {
     protected $report;
     protected $enforce;
     protected $compatHeaders;
     protected $hosts;
-    protected $contentTypes;
 
     public function __construct(DirectiveSet $report, DirectiveSet $enforce, $compatHeaders = true, array $hosts = array(), array $contentTypes = array())
     {
@@ -37,17 +34,6 @@ class ContentSecurityPolicyListener implements EventSubscriberInterface
             $response->headers->add($this->buildHeaders($this->report, true, $this->compatHeaders));
             $response->headers->add($this->buildHeaders($this->enforce, false, $this->compatHeaders));
         }
-    }
-
-    private function isContentTypeValid(Response $response)
-    {
-        if (empty($this->contentTypes)) {
-            return true;
-        }
-
-        $contentTypeData = explode(';', $response->headers->get('content-type'), 2);
-
-        return in_array(trim($contentTypeData[0]), $this->contentTypes, true);
     }
 
     private function buildHeaders(DirectiveSet $directiveSet, $reportOnly, $compatHeaders)

--- a/EventListener/ContentSecurityPolicyListener.php
+++ b/EventListener/ContentSecurityPolicyListener.php
@@ -2,6 +2,7 @@
 
 namespace Nelmio\SecurityBundle\EventListener;
 
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
@@ -14,13 +15,15 @@ class ContentSecurityPolicyListener implements EventSubscriberInterface
     protected $enforce;
     protected $compatHeaders;
     protected $hosts;
+    protected $contentTypes;
 
-    public function __construct(DirectiveSet $report, DirectiveSet $enforce, $compatHeaders = true, array $hosts = array())
+    public function __construct(DirectiveSet $report, DirectiveSet $enforce, $compatHeaders = true, array $hosts = array(), array $contentTypes = array())
     {
         $this->report = $report;
         $this->enforce = $enforce;
         $this->compatHeaders = $compatHeaders;
         $this->hosts = $hosts;
+        $this->contentTypes = $contentTypes;
     }
 
     public function onKernelResponse(FilterResponseEvent $e)
@@ -30,10 +33,21 @@ class ContentSecurityPolicyListener implements EventSubscriberInterface
         }
 
         $response = $e->getResponse();
-        if (empty($this->hosts) || in_array($e->getRequest()->getHost(), $this->hosts, true)) {
+        if ((empty($this->hosts) || in_array($e->getRequest()->getHost(), $this->hosts, true)) && $this->isContentTypeValid($response)) {
             $response->headers->add($this->buildHeaders($this->report, true, $this->compatHeaders));
             $response->headers->add($this->buildHeaders($this->enforce, false, $this->compatHeaders));
         }
+    }
+
+    private function isContentTypeValid(Response $response)
+    {
+        if (empty($this->contentTypes)) {
+            return true;
+        }
+
+        $contentTypeData = explode(';', $response->headers->get('content-type'), 2);
+
+        return in_array(trim($contentTypeData[0]), $this->contentTypes, true);
     }
 
     private function buildHeaders(DirectiveSet $directiveSet, $reportOnly, $compatHeaders)
@@ -81,6 +95,6 @@ class ContentSecurityPolicyListener implements EventSubscriberInterface
             }
         }
 
-        return new self($report, $enforce, (bool) $config['compat_headers'], $config['hosts']);
+        return new self($report, $enforce, !!$config['compat_headers'], $config['hosts']);
     }
 }

--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ nelmio_security:
                 - 'unsafe-eval'
                 - 'self'
             hosts: []
+            content_types: []
         enforce:
             # see https://github.com/nelmio/NelmioSecurityBundle/issues/32
             report-uri: [/nelmio/csp/report]
@@ -142,6 +143,9 @@ Apart from content types, the policy also accepts `report-uri` which should be a
 [JSON payload](https://developer.mozilla.org/en-US/docs/Security/CSP/Using_CSP_violation_reports#Sample_violation_report)
 to whenever a policy directive is violated.
 
+An optional `content_types` key lets you restrict the Content Security Policy headers only on some HTTP 
+response given their content type.
+
 Finally, an optional `hosts` key lets you configure which hostnames (e.g. `foo.example.org`)
 the CSP rule should be enforced on. If the list is empty (it is by default), all
 hostnames will use the CSP rule.
@@ -162,6 +166,7 @@ nelmio_security:
                 - facebook.com
                 - flickr.com
             hosts: []
+            content_types: []
         report:
             report-uri: /nelmio/csp/report
             script-src:
@@ -282,6 +287,7 @@ nelmio_security:
     clickjacking:
         paths:
             '^/.*': DENY
+        content_types: []
 ```
 
 Whitelist configuration (deny all but a few URLs):
@@ -294,6 +300,7 @@ nelmio_security:
             '^/business/': 'ALLOW FROM https://biz.example.org'
             '^/local/': SAMEORIGIN
             '^/.*': DENY
+        content_types: []
 ```
 
 You can also of course only deny a few critical URLs, while leaving the rest alone:
@@ -303,7 +310,11 @@ nelmio_security:
     clickjacking:
         paths:
             '^/message/write': DENY
+        content_types: []
 ```
+
+An optional `content_types` key lets you restrict the X-Frame-Options header only on some HTTP 
+response given their content type.
 
 ### **External Redirects Detection**:
 

--- a/Resources/config/clickjacking.yml
+++ b/Resources/config/clickjacking.yml
@@ -4,5 +4,6 @@ services:
         class: Nelmio\SecurityBundle\EventListener\ClickjackingListener
         arguments:
             - %nelmio_security.clickjacking.paths%
+            - %nelmio_security.clickjacking.content_types%
         tags:
-            - { name: kernel.event_listener, event: kernel.response, method: onKernelResponse }
+            - { name: kernel.event_subscriber }


### PR DESCRIPTION
This allows restriction on when to add clickjacking and CSP headers. For example, you can specify `text/html` so that these headers are only added in these cases.