### PR TITLE
Disable CSP headers on redirection

### DIFF
--- a/EventListener/ContentSecurityPolicyListener.php
+++ b/EventListener/ContentSecurityPolicyListener.php
@@ -30,6 +30,11 @@ class ContentSecurityPolicyListener extends AbstractContentTypeRestrictableListe
         }
 
         $response = $e->getResponse();
+
+        if ($response->isRedirection()) {
+            return;
+        }
+        
         if ((empty($this->hosts) || in_array($e->getRequest()->getHost(), $this->hosts, true)) && $this->isContentTypeValid($response)) {
             $response->headers->add($this->buildHeaders($this->report, true, $this->compatHeaders));
             $response->headers->add($this->buildHeaders($this->enforce, false, $this->compatHeaders));


### PR DESCRIPTION
I think we could disable CSP headers on any HTTP redirection, it does not make sense. What do you think about it?