### PR TITLE
fixes the parameter index

### DIFF
--- a/DependencyInjection/NelmioSecurityExtension.php
+++ b/DependencyInjection/NelmioSecurityExtension.php
@@ -92,7 +92,7 @@ class NelmioSecurityExtension extends Extension
             }
             if (!$config['external_redirects']['log']) {
                 $def = $container->getDefinition('nelmio_security.external_redirect_listener');
-                $def->replaceArgument(2, null);
+                $def->replaceArgument(4, null);
             }
         }
 


### PR DESCRIPTION
Right now, the $forwardAs parameter is set to null, but what we actually want to do here is set $logger to null. This fixes it :)