### PR TITLE
external_redirects definition can now contains full URL

### DIFF
--- a/DependencyInjection/NelmioSecurityExtension.php
+++ b/DependencyInjection/NelmioSecurityExtension.php
@@ -84,6 +84,10 @@ class NelmioSecurityExtension extends Extension
             $container->setParameter('nelmio_security.external_redirects.abort', $config['external_redirects']['abort']);
             if ($config['external_redirects']['whitelist']) {
                 $whitelist = array_map(function($el) {
+                    if ($host = parse_url($el, PHP_URL_HOST)) {
+                        return ltrim($host, '.');
+                    }
+
                     return ltrim($el, '.');
                 }, $config['external_redirects']['whitelist']);
                 $whitelist = array_map('preg_quote', $whitelist);


### PR DESCRIPTION
Hello.

I created this pull request, because it need it in my project.

My use case is:

I'm working on site A, that is a oAuth "client" of site B.
So some HTTP redirections occur from A to B.
We white-listed site B in our configuration, and that is working fine.

But now, I also run a (dev) copy of site B. And so the URL is different.
I don't want to pollute your config.yml with my local endpoint.

Therefore, I already have a parameter in my application to customize
the endpoint of B and I would like to re-use it. But my endpoint
parameter also constain the scheme.

That's why, if in the white-list, an url is provided, we extract
and use only the host part.

What do you think ?