### PR TITLE
Fix clickjacking rules definition to keep the correct order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 1.9.0 (2015-xx-xx)
+
+  * Deprecate clickjacking "paths" configuration in favor of "rules"
+
 ### 1.8.0 (2015-09-12)
 
   * Added HTTP response's content-type restriction for Clickjacking and CSP headers.

--- a/DependencyInjection/NelmioSecurityExtension.php
+++ b/DependencyInjection/NelmioSecurityExtension.php
@@ -51,7 +51,21 @@ class NelmioSecurityExtension extends Extension
 
         if (!empty($config['clickjacking'])) {
             $loader->load('clickjacking.yml');
-            $container->setParameter('nelmio_security.clickjacking.paths', $config['clickjacking']['paths']);
+
+            // Keep this for BC until 2.0
+            $rules = [];
+            foreach ($config['clickjacking']['paths'] as $path => $option) {
+                $rules[] = array('path' => $path, 'header' => $option['header']);
+            }
+
+            $rules = array_merge($rules, $config['clickjacking']['rules']);
+
+            // For BC, drop this when releasing 2.0
+            if (empty($rules)) {
+                $rules[] = array('path' => '^/.*', 'header' => 'DENY');
+            }
+
+            $container->setParameter('nelmio_security.clickjacking.rules', $rules);
             $container->setParameter('nelmio_security.clickjacking.content_types', $config['clickjacking']['content_types']);
         }
 

--- a/EventListener/ClickjackingListener.php
+++ b/EventListener/ClickjackingListener.php
@@ -17,11 +17,11 @@ use Symfony\Component\HttpKernel\KernelEvents;
 
 class ClickjackingListener extends AbstractContentTypeRestrictableListener
 {
-    private $paths;
+    private $rules;
 
-    public function __construct($paths, $contentTypes = array())
+    public function __construct($rules, $contentTypes = array())
     {
-        $this->paths = $paths;
+        $this->rules = $rules;
         $this->contentTypes = $contentTypes;
     }
 
@@ -48,12 +48,12 @@ class ClickjackingListener extends AbstractContentTypeRestrictableListener
 
         $currentPath = $e->getRequest()->getPathInfo() ?: '/';
 
-        foreach ($this->paths as $path => $options) {
-            if (preg_match('{'.$path.'}i', $currentPath)) {
-                if ('ALLOW' === $options['header']) {
+        foreach ($this->rules as $rule) {
+            if (preg_match('{'.$rule['path'].'}i', $currentPath)) {
+                if ('ALLOW' === $rule['header']) {
                     $response->headers->remove('X-Frame-Options');
                 } else {
-                    $response->headers->set('X-Frame-Options', $options['header']);
+                    $response->headers->set('X-Frame-Options', $rule['header']);
                 }
 
                 return;

--- a/README.md
+++ b/README.md
@@ -293,21 +293,22 @@ Default configuration (deny everything):
 ```yaml
 nelmio_security:
     clickjacking:
-        paths:
-            '^/.*': DENY
+        rules:
+            - { path: '^/.*', header: 'DENY' }
         content_types: []
 ```
 
-Whitelist configuration (deny all but a few URLs):
+Whitelist configuration (deny all but a few URLs). First rule that match, from top to bottom, 
+stops and apply the corresponding header:
 
 ```yaml
 nelmio_security:
     clickjacking:
-        paths:
-            '^/iframes/': ALLOW
-            '^/business/': 'ALLOW FROM https://biz.example.org'
-            '^/local/': SAMEORIGIN
-            '^/.*': DENY
+        rules:
+            - { path: '^/iframes/', header: 'ALLOW' }
+            - { path: '^/business/', header: 'ALLOW FROM https://biz.example.org' }
+            - { path: '^/local/', header: 'SAMEORIGIN' }
+            - { path: '^/.*', header: 'DENY' }
         content_types: []
 ```
 
@@ -316,8 +317,8 @@ You can also of course only deny a few critical URLs, while leaving the rest alo
 ```yaml
 nelmio_security:
     clickjacking:
-        paths:
-            '^/message/write': DENY
+        rules:
+            - { path: '^/message/write', header: 'DENY' }
         content_types: []
 ```
 

--- a/Resources/config/clickjacking.yml
+++ b/Resources/config/clickjacking.yml
@@ -3,7 +3,7 @@ services:
         scope: request
         class: Nelmio\SecurityBundle\EventListener\ClickjackingListener
         arguments:
-            - '%nelmio_security.clickjacking.paths%'
+            - '%nelmio_security.clickjacking.rules%'
             - '%nelmio_security.clickjacking.content_types%'
         tags:
             - { name: kernel.event_subscriber }

--- a/Tests/Listener/ClickjackingListenerTest.php
+++ b/Tests/Listener/ClickjackingListenerTest.php
@@ -27,10 +27,10 @@ class ClickjackingListenerTest extends \PHPUnit_Framework_TestCase
     {
         $this->kernel = $this->getMock('Symfony\Component\HttpKernel\HttpKernelInterface');
         $this->listener = new ClickjackingListener(array(
-            '^/frames/' => array('header' => 'ALLOW'),
-            '/frames/' => array('header' => 'SAMEORIGIN'),
-            '^/.*' => array('header' => 'DENY'),
-            '.*' => array('header' => 'ALLOW'),
+            array('path' => '^/frames/', 'header' => 'ALLOW'),
+            array('path' => '/frames/', 'header' => 'SAMEORIGIN'),
+            array('path' => '^/.*', 'header' => 'DENY'),
+            array('path' => '.*', 'header' => 'ALLOW'),
         ));
     }
 
@@ -78,10 +78,10 @@ class ClickjackingListenerTest extends \PHPUnit_Framework_TestCase
     public function testClickjackingWithContentTypes($contentType, $result)
     {
         $this->listener = new ClickjackingListener(array(
-            '^/frames/' => array('header' => 'ALLOW'),
-            '/frames/' => array('header' => 'SAMEORIGIN'),
-            '^/.*' => array('header' => 'DENY'),
-            '.*' => array('header' => 'ALLOW'),
+            array('path' => '^/frames/', 'header' => 'ALLOW'),
+            array('path' => '/frames/', 'header' => 'SAMEORIGIN'),
+            array('path' => '^/.*', 'header' => 'DENY'),
+            array('path' => '.*', 'header' => 'ALLOW'),
         ), array('text/html'));
 
         $response = $this->callListener($this->listener, '/', true, $contentType);


### PR DESCRIPTION
Hello,

At the moment, it's possible to declare multiple paths for the clickjacking, for example

```
    clickjacking:
        content_types: ['text/html']
        paths:
            '/myroute/embed': ALLOW
            '^/': DENY
```

However, due to how Symfony Config merges associative arrays, it sorts it by keys, and this result into this inside the listener:
```
array(2) {
  ["^/"]=>
  array(1) {
    ["header"]=>
    string(4) "DENY"
  }
  ["/myroute/embed"]=>
  array(1) {
    ["header"]=>
    string(5) "ALLOW"
  }
}
```
First matching rule is applied, everything is denied :( (smiley vraiment triste).

I don't want to patch Symfony, as PHP7 and HHVM do not guarantee that an hashmap order is still conserved.
So I propose this BC patch that introduce new "rules" (inspired by security bundle):

```
    clickjacking:
        content_types: ['text/html']
        rules:
            - { path:'^/myroute/embed$', header: ALLOW }
            - { path:'^/', header: DENY }
```

As this array is now indexed, it's not sorted anymore and I got this in the listener:

```
array(2) {
  [0]=>
  array(2) {
    ["path"]=>
    string(16) "^/myroute/embed$"
    ["header"]=>
    string(5) "ALLOW"
  }
  [1]=>
  array(2) {
    ["path"]=>
    string(2) "^/"
    ["header"]=>
    string(4) "DENY"
  }
}
```

This patch is fully BC (no need to change any config for upgrading users) and could be drop easily in 2.0 (I commented everywhere it's needed). I can even create the upcoming PR for dropping this.
However, I doubt any user use this feature, because it does not work at the moment :D

I hope it would satisfy everybody.

With love!