### PR TITLE
Allow dynamix CSP configuration

### DIFF
--- a/EventListener/ContentSecurityPolicyListener.php
+++ b/EventListener/ContentSecurityPolicyListener.php
@@ -23,6 +23,16 @@ class ContentSecurityPolicyListener extends AbstractContentTypeRestrictableListe
         $this->contentTypes = $contentTypes;
     }
 
+    public function getReport()
+    {
+        return $this->report;
+    }
+
+    public function getEnforcement()
+    {
+        return $this->enforce;
+    }
+
     public function onKernelResponse(FilterResponseEvent $e)
     {
         if (HttpKernelInterface::MASTER_REQUEST !== $e->getRequestType()) {


### PR DESCRIPTION
This PR adds getter on report and enforce DirectiveSet to allow them to be customize later after initialization.
This is particularly nice in some use case:

 - Add extra parameters to the report-uri (a debug token link for instance)
 - Extend a security policy directive on a admin backend which needs specific access on some resources