### PR TITLE
Fix normalization for URLs containing dash and no underscore

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -59,6 +59,7 @@ class Configuration implements ConfigurationInterface
                     ->fixXmlConfig('path')
                     ->children()
                         ->arrayNode('paths')
+                            ->normalizeKeys(false)
                             ->useAttributeAsKey('pattern')
                             ->prototype('array')
                                 ->beforeNormalization()


### PR DESCRIPTION
Symfony config normalize array keys that contains dashes and no underscore, see https://github.com/symfony/symfony/pull/17129 . 
We should not allow normalization on clickjacking keys in rules definition because it breaks the configuration.
For instance, the following conf:
```
        paths:
            '^/[a-zA-Z]+$': 'ALLOW'
            '^/': 'DENY'
```
becomes after normalization:
```
array(2) {
  ["^/[a_zA_Z]+$"]=>
  array(1) {
    ["header"]=>
    string(5) "ALLOW"
  }
  ["^/"]=>
  array(1) {
    ["header"]=>
    string(4) "DENY"
  }
}
```

This patch fixes this behavior