### PR TITLE
Remove scope property from services that does not use it

### DIFF
--- a/Resources/config/clickjacking.yml
+++ b/Resources/config/clickjacking.yml
@@ -1,6 +1,5 @@
 services:
     nelmio_security.clickjacking_listener:
-        scope: request
         class: Nelmio\SecurityBundle\EventListener\ClickjackingListener
         arguments:
             - '%nelmio_security.clickjacking.paths%'

--- a/Resources/config/content_type.yml
+++ b/Resources/config/content_type.yml
@@ -1,6 +1,5 @@
 services:
     nelmio_security.content_type_listener:
-        scope: request
         class: Nelmio\SecurityBundle\EventListener\ContentTypeListener
         arguments:
             - '%nelmio_security.content_type.nosniff%'

--- a/Resources/config/encrypted_cookie.yml
+++ b/Resources/config/encrypted_cookie.yml
@@ -1,6 +1,5 @@
 services:
     nelmio_security.encrypted_cookie_listener:
-        scope: request
         class: Nelmio\SecurityBundle\EventListener\EncryptedCookieListener
         arguments:
             - '@nelmio_security.encrypter'

--- a/Resources/config/external_redirects.yml
+++ b/Resources/config/external_redirects.yml
@@ -3,7 +3,6 @@ parameters:
 
 services:
     nelmio_security.external_redirect_listener:
-        scope: request
         class: Nelmio\SecurityBundle\EventListener\ExternalRedirectListener
         arguments:
             - '%nelmio_security.external_redirects.abort%'

--- a/Resources/config/signed_cookie.yml
+++ b/Resources/config/signed_cookie.yml
@@ -1,6 +1,5 @@
 services:
     nelmio_security.signed_cookie_listener:
-        scope: request
         class: Nelmio\SecurityBundle\EventListener\SignedCookieListener
         arguments:
             - '@nelmio_security.signer'


### PR DESCRIPTION
Scopes are not supported anymore in Symfony 3. This bundle declares services scoped to the "request" service. However, I don't see any dependency on request in any of them.

I don't think I'm wrong, anyway, I'd love a review by @stof :)

Thanks a lot