### PR TITLE
Stronger directives definition, deprecate report-uri as array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### 2.0.0 (2016-xx-xx)
   * Add support for Content-Security-Policy Level 2 directives
+  * Deprecate report-uri as an array. Property is now a scalar
   * Drop backward-compatibility with first deprecated CSP configuration
 
 ### 1.10.0 (2016-02-23)

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ nelmio_security:
     # prevents inline scripts, unsafe eval, external scripts/images/styles/frames, etc
     csp:
         report:
-            report-uri: [/nelmio/csp/report]
+            report-uri: /nelmio/csp/report
             default-src: [ 'self' ]
             # There's no flash on our site
             object-src:
@@ -106,7 +106,7 @@ nelmio_security:
             content_types: []
         enforce:
             # see https://github.com/nelmio/NelmioSecurityBundle/issues/32
-            report-uri: [/nelmio/csp/report]
+            report-uri: /nelmio/csp/report
             script-src:
                 - 'self'
 

--- a/Tests/ContentSecurityPolicy/DirectiveSetTest.php
+++ b/Tests/ContentSecurityPolicy/DirectiveSetTest.php
@@ -55,7 +55,7 @@ class DirectiveSetTest extends \PHPUnit_Framework_TestCase
                     'plugin-types' => array('application/shockwave-flash'),
                     'block-all-mixed-content' => true,
                     'upgrade-insecure-requests' => true,
-                )
+                ),
             ),
             array(
                 'default-src example.org \'self\'; '.
@@ -91,7 +91,7 @@ class DirectiveSetTest extends \PHPUnit_Framework_TestCase
                     'plugin-types' => array('application/shockwave-flash'),
                     'block-all-mixed-content' => false,
                     'upgrade-insecure-requests' => false,
-                )
+                ),
             ),
             array(
                 'default-src example.org \'self\'; '.
@@ -125,7 +125,15 @@ class DirectiveSetTest extends \PHPUnit_Framework_TestCase
                     'form-action' => array('form-action.example.org', "'self'"),
                     'frame-ancestors' => array('frame-ancestors.example.org', "'self'"),
                     'plugin-types' => array('application/shockwave-flash'),
-                )
+                ),
+            ),
+            array(
+                'default-src \'none\'; '.
+                'plugin-types \'none\'',
+                array(
+                    'default-src' => array('none'),
+                    'plugin-types' => array('none'),
+                ),
             ),
         );
     }

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -21,6 +21,40 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
         );
     }
 
+    public function testReportUriScalar()
+    {
+        $this->processYamlConfiguration(
+            "csp:\n".
+            "  enforce:\n".
+            "    report-uri: /csp/report\n"
+        );
+    }
+
+    public function testReportUriArray()
+    {
+        $this->processYamlConfiguration(
+            "csp:\n".
+            "  enforce:\n".
+            "    report-uri:\n".
+            "      - /csp/report\n"
+        );
+    }
+
+    /**
+     * @expectedException Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
+     * @expectedExceptionMessage Only one report-uri should be provided
+     */
+    public function testReportUriInvalidArray()
+    {
+        $this->processYamlConfiguration(
+            "csp:\n".
+            "  enforce:\n".
+            "    report-uri:\n".
+            "      - /csp/report1\n".
+            "      - /csp/report2\n"
+        );
+    }
+
     public function testCspWithLevel2()
     {
         $this->processYamlConfiguration(


### PR DESCRIPTION
This fixes a bug where we fallback on default-src whereas it's not a source-list (like plugin-types)