### PR TITLE
Allow multiple report-uri

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ### 2.0.0 (2016-xx-xx)
   * Add support for Content-Security-Policy Level 2 directives
   * Add support for Content-Security-Policy Level 2 signatures (nonce and message digest)
-  * Deprecate report-uri as an array. Property is now a scalar
+  * Allow report-uri to be defined as a scalar
   * Deprecate encrypted cookie support du to high coupling to mcrypt deprecated extension
   * Drop backward-compatibility with first deprecated CSP configuration
 

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -218,22 +218,9 @@ class Configuration implements ConfigurationInterface
                     ->arrayNode($name)
                         ->prototype('scalar')->end()
                         ->beforeNormalization()
-                            ->ifArray()
-                            ->then(function ($value) {
-                                @trigger_error("Using an array for configuring 'report-uri' directive is deprecated", E_USER_NOTICE);
-
-                                return $value;
-                            })
-                        ->end()
-                        ->beforeNormalization()
                             ->ifString()
                             ->then(function ($value) { return array($value); })
                         ->end()
-                        ->validate()
-                        ->ifTrue(function ($v) {
-                            return count($v) > 1;
-                        })
-                        ->thenInvalid('Only one report-uri should be provided')
                     ->end();
             } elseif (DirectiveSet::TYPE_URI_REFERENCE === $type) {
                 $children->scalarNode($name)

--- a/Tests/ContentSecurityPolicy/DirectiveSetTest.php
+++ b/Tests/ContentSecurityPolicy/DirectiveSetTest.php
@@ -139,6 +139,14 @@ class DirectiveSetTest extends \PHPUnit_Framework_TestCase
                     'form-action' => array('none'),
                 ),
             ),
+            array(
+                'default-src \'none\'; '.
+                'report-uri /csp/report1 /csp/report2',
+                array(
+                    'default-src' => array('none'),
+                    'report-uri' => array('/csp/report1', '/csp/report2'),
+                ),
+            ),
         );
     }
 

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -40,11 +40,7 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
         );
     }
 
-    /**
-     * @expectedException Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
-     * @expectedExceptionMessage Only one report-uri should be provided
-     */
-    public function testReportUriInvalidArray()
+    public function testReportUriValidWithMultiple()
     {
         $this->processYamlConfiguration(
             "csp:\n".


### PR DESCRIPTION
According to the RFC, using multiple report-uri is valid. It reverts a part of my last changes on this topic