### PR TITLE
Add parameters "type" and "logLevel" to ContentSecurityPolicyController

### DIFF
--- a/Controller/ContentSecurityPolicyController.php
+++ b/Controller/ContentSecurityPolicyController.php
@@ -12,15 +12,31 @@
 namespace Nelmio\SecurityBundle\Controller;
 
 use Psr\Log\LoggerInterface;
+use Psr\Log\LogLevel;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use UnexpectedValueException;
 
 class ContentSecurityPolicyController
 {
+    const TYPE_ENFORCE = 'enforce';
+    const TYPE_REPORT = 'report';
+
     /**
      * @var LoggerInterface
      */
     protected $logger;
+
+    private $logLevels = array(
+        LogLevel::EMERGENCY => LogLevel::EMERGENCY,
+        LogLevel::ALERT => LogLevel::ALERT,
+        LogLevel::CRITICAL => LogLevel::CRITICAL,
+        LogLevel::ERROR => LogLevel::ERROR,
+        LogLevel::WARNING => LogLevel::WARNING,
+        LogLevel::NOTICE => LogLevel::NOTICE,
+        LogLevel::INFO => LogLevel::INFO,
+        LogLevel::DEBUG => LogLevel::DEBUG,
+    );
 
     /**
      * @param LoggerInterface $logger
@@ -30,33 +46,65 @@ class ContentSecurityPolicyController
         $this->logger = $logger;
     }
 
-    public function indexAction(Request $request)
+    public function indexAction(Request $request, $type = self::TYPE_ENFORCE, $logLevel = LogLevel::NOTICE)
     {
+        $this->validateLogLevel($logLevel);
+
+        $messagePrefix = $this->getMessagePrefix($type);
+
         $violationReport = $request->getContent();
         if (empty($violationReport)) {
-            $this->logger->notice('Content-Security-Policy Endpoint called without data');
+            $this->logger->log($logLevel,
+                sprintf('[%s] Content-Security-Policy Endpoint called without data', $messagePrefix)
+            );
 
             return new Response('No report data sent?', 411);
         }
 
         $violationReport = json_decode($violationReport, true);
         if ($violationReport === null) {
-            $this->logger->notice('Content-Security-Policy Endpoint called with invalid JSON data');
+            $this->logger->log($logLevel,
+                sprintf('[%s] Content-Security-Policy Endpoint called with invalid JSON data', $messagePrefix)
+            );
 
             return new Response('Invalid JSON data supplied?', 400);
         }
 
         if (!isset($violationReport['csp-report'])) {
-            $this->logger->notice('Content-Security-Policy Endpoint called without "csp-report" data');
+            $this->logger->log($logLevel,
+                sprintf('[%s] Content-Security-Policy Endpoint called without "csp-report" data', $messagePrefix)
+            );
 
             return new Response('Invalid report data, no "csp-report" data supplied.', 400);
         }
 
-        $this->logger->notice(
-            'Content-Security-Policy Violation Reported',
+        $this->logger->log($logLevel,
+            sprintf('[%s] Content-Security-Policy Violation Reported', $messagePrefix),
             $violationReport
         );
 
         return new Response('', 204);
+    }
+
+    private function getMessagePrefix($type)
+    {
+        if (self::TYPE_ENFORCE === $type) {
+            return 'Enforce';
+        }
+
+        if (self::TYPE_REPORT === $type) {
+            return 'Report Only';
+        }
+
+        throw new UnexpectedValueException(sprintf('The "type" parameter accepts values: "%s" or "%s", "%s" given.', self::TYPE_ENFORCE, self::TYPE_REPORT, $type));
+    }
+
+    private function validateLogLevel($logLevel)
+    {
+        if (isset($this->logLevels[$logLevel])) {
+            return;
+        }
+
+        throw new UnexpectedValueException(sprintf('The "logLevel" parameter "%s" is unknown. Use one of log levels defined in class "Psr\Log\LogLevel".', $logLevel));
     }
 }

--- a/README.md
+++ b/README.md
@@ -217,6 +217,44 @@ nelmio_security:
     methods:  [POST]
 ```
 
+(Optional) Specify the `type` parameter in the routing:
+
+Default value: `enforce`.
+The `type` parameter accepts value `enforce` or `report` for declaring different report uris
+for `enforce` and `report-only` CSP directive. Based on the selected type the log message created by the controller differs.
+
+```yaml
+nelmio_security_enforce:
+    path:     /nelmio/csp/report/enforce
+    defaults:
+       _controller: nelmio_security.csp_reporter_controller:indexAction
+       type:        "enforce"
+    methods:  [POST]
+
+nelmio_security_report_only:
+    path:     /nelmio/csp/report/report-only
+    defaults:
+       _controller: nelmio_security.csp_reporter_controller:indexAction
+       type:        "report"
+    methods:  [POST]
+```
+
+(Optional) Specify the `logLevel` parameter in the routing:
+
+Default value: `notice`.
+
+```yaml
+nelmio_security:
+    path:     /nelmio/csp/report
+    defaults:
+       _controller: nelmio_security.csp_reporter_controller:indexAction
+       logLevel:    "warning"
+    methods:  [POST]
+```
+
+The `logLevel` parameter accepts any of the [`Psr\Log\LogLevel`](http://www.php-fig.org/psr/psr-3/#5-psr-log-loglevel)
+values, e.g. `notice`, `warning`, `error`.
+
 (Optional) Use *report_logger_service* to log to the 'security' channel:
 
 ```yaml


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | "master" |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #32 |
| License | MIT |

Let the user decide which level for CSP report will be used. 
Allow defining two different routes for `enforce` and `report` CSP reports.
