### PR TITLE
Add support for Referrer Policy

### DIFF
--- a/DependencyInjection/NelmioSecurityExtension.php
+++ b/DependencyInjection/NelmioSecurityExtension.php
@@ -142,6 +142,11 @@ class NelmioSecurityExtension extends Extension
             $container->setParameter('nelmio_security.forced_ssl.whitelist', $config['forced_ssl']['whitelist']);
             $container->setParameter('nelmio_security.forced_ssl.hosts', $config['forced_ssl']['hosts']);
         }
+
+        if (!empty($config['referrer_policy']) && $config['referrer_policy']['enabled']) {
+            $loader->load('referrer_policy.yml');
+            $container->setParameter('nelmio_security.referrer_policy.policies', $config['referrer_policy']['policies']);
+        }
     }
 
     private function buildDirectiveSetDefinition(ContainerBuilder $container, $config, $type)

--- a/EventListener/ReferrerPolicyListener.php
+++ b/EventListener/ReferrerPolicyListener.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of the Nelmio SecurityBundle.
+ *
+ * (c) Nelmio <hello@nelm.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\SecurityBundle\EventListener;
+
+use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+
+/**
+ * Referrer Policy Listener.
+ *
+ * @author Andrej Hudec <pulzarraider@gmail.com>
+ */
+class ReferrerPolicyListener
+{
+    private $policies;
+
+    public function __construct(array $policies)
+    {
+        $this->policies = $policies;
+    }
+
+    public function onKernelResponse(FilterResponseEvent $e)
+    {
+        if (HttpKernelInterface::MASTER_REQUEST !== $e->getRequestType()) {
+            return;
+        }
+
+        $response = $e->getResponse();
+
+        $response->headers->set('Referrer-Policy', implode(', ', $this->policies));
+    }
+}

--- a/README.md
+++ b/README.md
@@ -66,6 +66,9 @@ load content from another domain than the page's domain.
 
 * **[XSS Protection](#xss-protection)**: Enables/Disables Microsoft XSS Protection on compatible browsers (IE 8 and newer).
 
+* **[Referrer Policy](#referrer-policy)**: `Referrer-Policy` header is added to all responses to control the `Referer` header
+  that is added to requests made from your site, and for navigations away from your site by browsers.
+
 **WARNING**: The following features are now deprecated:
 
 * **[Encrypted Cookies](#encrypted-cookies)**: Specify certain cookies to be encrypted, so that the value cannot be
@@ -112,6 +115,17 @@ nelmio_security:
     xss_protection:
         enabled: true
         mode_block: true
+
+    # Send a full URL in the `Referer` header when performing a same-origin request,
+    # only send the origin of the document to secure destination (HTTPS->HTTPS),
+    # and send no header to a less secure destination (HTTPS->HTTP).
+    # If `strict-origin-when-cross-origin` is not supported, use `no-referrer` policy,
+    # no referrer information is sent along with requests.
+    referrer_policy:
+        enabled: true
+        policies:
+            - 'no-referrer'
+            - 'strict-origin-when-cross-origin'
 
     # forces HTTPS handling, don't combine with flexible mode
     # and make sure you have SSL working on your site before enabling this
@@ -729,6 +743,40 @@ nelmio_security:
     xss_protection:
         enabled: true
         mode_block: true
+```
+
+### Referrer Policy
+
+Adds `Referrer-Policy` header to control the `Referer` header that is added
+to requests made from your site, and for navigations away from your site by browsers.
+
+You can specify multiple [referrer policies](https://www.w3.org/TR/referrer-policy/#referrer-policies).
+The order of the policies is important. Browser will choose only the last policy they understand.
+For example older browsers don’t understand the `strict-origin-when-cross-origin` policy.
+A site can specify a `no-referrer` policy followed by a `strict-origin-when-cross-origin` policy:
+older browsers will ignore the unknown `strict-origin-when-cross-origin` value and use `no-referrer`,
+while newer browsers will use `strict-origin-when-cross-origin` because it is the last to be processed.
+
+A referrer policy is:
+  * [`no-referrer`](https://www.w3.org/TR/referrer-policy/#referrer-policy-no-referrer),
+  * [`no-referrer-when-downgrade`](https://www.w3.org/TR/referrer-policy/#referrer-policy-no-referrer-when-downgrade),
+  * [`same-origin`](https://www.w3.org/TR/referrer-policy/#referrer-policy-same-origin),
+  * [`origin`](https://www.w3.org/TR/referrer-policy/#referrer-policy-origin),
+  * [`strict-origin`](https://www.w3.org/TR/referrer-policy/#referrer-policy-strict-origin),
+  * [`origin-when-cross-origin`](https://www.w3.org/TR/referrer-policy/#referrer-policy-origin-when-cross-origin),
+  * [`strict-origin-when-cross-origin`](https://www.w3.org/TR/referrer-policy/#referrer-policy-strict-origin-when-cross-origin),
+  * [`unsafe-url`](https://www.w3.org/TR/referrer-policy/#referrer-policy-unsafe-url),
+  * [the empty string](https://www.w3.org/TR/referrer-policy/#referrer-policy-empty-string).
+
+For better security of your site please use `no-referrer`, `same-origin`, `strict-origin` or `strict-origin-when-cross-origin`.
+
+```yaml
+nelmio_security:
+    referrer_policy:
+        enabled: true
+        policies:
+            - 'no-referrer'
+            - 'strict-origin-when-cross-origin'
 ```
 
 ## License

--- a/Resources/config/referrer_policy.yml
+++ b/Resources/config/referrer_policy.yml
@@ -1,0 +1,8 @@
+services:
+    nelmio_security.referrer_policy_listener:
+        class: Nelmio\SecurityBundle\EventListener\ReferrerPolicyListener
+        arguments:
+            - '%nelmio_security.referrer_policy.policies%'
+
+        tags:
+            - { name: kernel.event_listener, event: kernel.response, method: onKernelResponse }

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -1,9 +1,18 @@
 <?php
 
+/*
+ * This file is part of the Nelmio SecurityBundle.
+ *
+ * (c) Nelmio <hello@nelm.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Nelmio\SecurityBundle\Tests\DependencyInjection;
 
-use Symfony\Component\Config\Definition\Processor;
 use Nelmio\SecurityBundle\DependencyInjection\Configuration;
+use Symfony\Component\Config\Definition\Processor;
 use Symfony\Component\Yaml\Parser;
 
 class ConfigurationTest extends \PHPUnit_Framework_TestCase
@@ -83,7 +92,39 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
             "      - 'self'\n".
             "    browser_adaptive:\n".
             "      enabled: true\n".
-            "      parser: service_name"
+            "      parser: service_name\n"
+        );
+    }
+
+    public function testReferrerPolicy()
+    {
+        $this->processYamlConfiguration(
+            "referrer_policy:\n".
+            "  enabled: true\n".
+            "  policies:\n".
+            "    - 'no-referrer'\n".
+            "    - 'no-referrer-when-downgrade'\n".
+            "    - 'same-origin'\n".
+            "    - 'origin'\n".
+            "    - 'strict-origin'\n".
+            "    - 'origin-when-cross-origin'\n".
+            "    - 'strict-origin-when-cross-origin'\n".
+            "    - 'unsafe-url'\n".
+            "    - ''\n"
+        );
+    }
+
+    /**
+     * @expectedException Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
+     */
+    public function testReferrerPolicyInvalid()
+    {
+        $this->processYamlConfiguration(
+            "referrer_policy:\n".
+            "  enabled: true\n".
+            "  policies:\n".
+            "    - 'no-referrer'\n".
+            "    - 'foo'\n"
         );
     }
 

--- a/Tests/Listener/ReferrerPolicyListenerTest.php
+++ b/Tests/Listener/ReferrerPolicyListenerTest.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * This file is part of the Nelmio SecurityBundle.
+ *
+ * (c) Nelmio <hello@nelm.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\SecurityBundle\Tests\Listener;
+
+use Nelmio\SecurityBundle\EventListener\ReferrerPolicyListener;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+
+class ReferrerPolicyListenerTest extends \PHPUnit_Framework_TestCase
+{
+    private $kernel;
+
+    protected function setUp()
+    {
+        $this->kernel = $this->getMock('Symfony\Component\HttpKernel\HttpKernelInterface');
+    }
+
+    /**
+     * @dataProvider provideVariousConfigs
+     */
+    public function testVariousConfig($expectedValue, $listener)
+    {
+        $response = $this->callListener($listener, '/', true);
+
+        $this->assertEquals($expectedValue, $response->headers->get('Referrer-Policy'));
+    }
+
+    public function provideVariousConfigs()
+    {
+        return array(
+            array('', new ReferrerPolicyListener(array())),
+            array('no-referrer', new ReferrerPolicyListener(array('no-referrer'))),
+            array('no-referrer, strict-origin-when-cross-origin', new ReferrerPolicyListener(array('no-referrer', 'strict-origin-when-cross-origin'))),
+            array('no-referrer, no-referrer-when-downgrade, strict-origin-when-cross-origin', new ReferrerPolicyListener(array('no-referrer', 'no-referrer-when-downgrade', 'strict-origin-when-cross-origin'))),
+        );
+    }
+
+    protected function callListener(ReferrerPolicyListener $listener, $path, $masterReq)
+    {
+        $request = Request::create($path);
+        $response = new Response();
+
+        $event = new FilterResponseEvent(
+            $this->kernel,
+            $request,
+            $masterReq ? HttpKernelInterface::MASTER_REQUEST : HttpKernelInterface::SUB_REQUEST,
+            $response
+        );
+        $listener->onKernelResponse($event);
+
+        return $response;
+    }
+}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | `master` |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |

Documentation: https://www.w3.org/TR/referrer-policy/
Even it is  working draft, some browsers has already implemented the specification:

- Chrome - currently supports [older version](https://www.w3.org/TR/2016/WD-referrer-policy-20160601/) of the draft [without the `same-origin`,`strict-origin`,`strict-origin-when-cross-origin` policies since version 56](https://www.chromestatus.com/feature/5639972996513792)
- Firefox - currently supports [older version](https://www.w3.org/TR/2016/WD-referrer-policy-20160601/) of the draft [without the `same-origin`,`strict-origin`,`strict-origin-when-cross-origin` policies since version 50](https://bugzilla.mozilla.org/show_bug.cgi?id=1264164). The full version wil be available [since version 52](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referrer-Policy#Browser_compatibility)
- Opera - currently supports [older version](https://www.w3.org/TR/2016/WD-referrer-policy-20160601/) of the draft [without the `same-origin`,`strict-origin`,`strict-origin-when-cross-origin` policies since version 43](https://www.chromestatus.com/feature/5639972996513792))

