### PR TITLE
Add $usage argument when generating a nonce

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 2.4.0 (2017-xx-xx)
+
+  * Deprecate calling ContentSecurityPolicyListener::getNonce without usage ('script' or 'style')
+
 ### 2.3.1 (2017-03-17)
 
   * Fix arguments for Twig extension

--- a/README.md
+++ b/README.md
@@ -378,7 +378,9 @@ If you're not using Twig, you can use nonce functionality with the `ContentSecur
 
 ```php
 // generates a nonce at first time, returns the same nonce once generated
-$listener->getNonce();
+$listener->getNonce('script');
+// or
+$listener->getNonce('style');
 ```
 
 #### Reporting:

--- a/Tests/Listener/ContentSecurityPolicyListenerTest.php
+++ b/Tests/Listener/ContentSecurityPolicyListenerTest.php
@@ -37,6 +37,25 @@ class ContentSecurityPolicyListenerTest extends \PHPUnit_Framework_TestCase
             ->will($this->returnValue('sha-style'));
     }
 
+    /**
+     * @group legacy
+     * @expectedDeprecation Retrieving a nonce without a usage is deprecated since version 2.4, and will be removed in version 3
+     */
+    public function testDeprecationNotice()
+    {
+        $listener = $this->buildSimpleListener(array('default-src' => "default.example.org 'self'"));
+        $listener->getNonce();
+    }
+
+    /**
+     * @expectedException Invalid usage provided
+     */
+    public function tesInvalidArgumentException()
+    {
+        $listener = $this->buildSimpleListener(array('default-src' => "default.example.org 'self'"));
+        $listener->getNonce('prout');
+    }
+
     public function testDefault()
     {
         $listener = $this->buildSimpleListener(array('default-src' => "default.example.org 'self'"));
@@ -416,7 +435,8 @@ class ContentSecurityPolicyListenerTest extends \PHPUnit_Framework_TestCase
         }
 
         for ($i = 0; $i < $getNonce; ++$i) {
-            $listener->getNonce();
+            $listener->getNonce('script');
+            $listener->getNonce('style');
         }
 
         $response = new Response();

--- a/Twig/NelmioCSPTwigExtension.php
+++ b/Twig/NelmioCSPTwigExtension.php
@@ -49,9 +49,9 @@ class NelmioCSPTwigExtension extends \Twig_Extension
         );
     }
 
-    public function getCSPNonce()
+    public function getCSPNonce($usage = null)
     {
-        if (null === $nonce = $this->listener->getNonce()) {
+        if (null === $nonce = $this->listener->getNonce($usage)) {
             throw new \RuntimeException('You must enable nonce to use this feature');
         }
 

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "2.3.x-dev"
+            "dev-master": "2.4.x-dev"
         }
     }
 }


### PR DESCRIPTION
At the moment, it's not possible to generate a nonce only for the `script-src` directive. Once a nonce is generated, it's added to both `script-src` and `style-src` directives. 

At the moment it prevents using `unsafe-inline`for `style-src` directive while the `script-src` directive uses a nonce.

This PR solves this issue