### PR TITLE
Skip setting Strict-Transport-Security header for none-secure requests

### DIFF
--- a/EventListener/ForcedSslListener.php
+++ b/EventListener/ForcedSslListener.php
@@ -66,7 +66,8 @@ class ForcedSslListener
             return;
         }
 
-        // skip none-SSL requests
+        // skip non-SSL requests as per the RFC
+        // "An HSTS Host MUST NOT include the STS header field in HTTP responses conveyed over non-secure transport."
         $request = $e->getRequest();
         if (!$request->isSecure()) {
             return;

--- a/EventListener/ForcedSslListener.php
+++ b/EventListener/ForcedSslListener.php
@@ -66,6 +66,12 @@ class ForcedSslListener
             return;
         }
 
+        // skip none-SSL requests
+        $request = $e->getRequest();
+        if (!$request->isSecure()) {
+            return;
+        }
+
         $response = $e->getResponse();
 
         if (!$response->headers->has('Strict-Transport-Security')) {

--- a/Tests/Listener/ForcedSslListenerTest.php
+++ b/Tests/Listener/ForcedSslListenerTest.php
@@ -38,6 +38,17 @@ class ForcedSslListenerTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($result, $response->headers->get('Strict-Transport-Security'));
     }
 
+    /**
+     * @dataProvider provideHstsHeaders
+     */
+    public function testHstsHeadersNotSetForNonSecureRequest($hstsMaxAge, $hstsSubdomains, $hstsPreload)
+    {
+        $listener = new ForcedSslListener($hstsMaxAge, $hstsSubdomains, $hstsPreload);
+
+        $response = $this->callListenerResp($listener, 'http://localhost/', true);
+        $this->assertSame(null, $response->headers->get('Strict-Transport-Security'));
+    }
+
     public function provideHstsHeaders()
     {
         return array(

--- a/Tests/Listener/ForcedSslListenerTest.php
+++ b/Tests/Listener/ForcedSslListenerTest.php
@@ -34,7 +34,7 @@ class ForcedSslListenerTest extends \PHPUnit_Framework_TestCase
     {
         $listener = new ForcedSslListener($hstsMaxAge, $hstsSubdomains, $hstsPreload);
 
-        $response = $this->callListenerResp($listener, '/', true);
+        $response = $this->callListenerResp($listener, 'https://localhost/', true);
         $this->assertSame($result, $response->headers->get('Strict-Transport-Security'));
     }
 
@@ -54,7 +54,7 @@ class ForcedSslListenerTest extends \PHPUnit_Framework_TestCase
     {
         $listener = new ForcedSslListener(60, true);
 
-        $response = $this->callListenerResp($listener, '/', false);
+        $response = $this->callListenerResp($listener, 'https://localhost/', false);
         $this->assertSame(null, $response->headers->get('Strict-Transport-Security'));
     }
 
@@ -62,13 +62,13 @@ class ForcedSslListenerTest extends \PHPUnit_Framework_TestCase
     {
         $listener = new ForcedSslListener(60, true, false, array('^/foo/', 'bar'));
 
-        $response = $this->callListenerReq($listener, '/foo/lala', true);
+        $response = $this->callListenerReq($listener, 'http://localhost/foo/lala', true);
         $this->assertSame(null, $response);
 
-        $response = $this->callListenerReq($listener, '/lala/foo/lala', true);
+        $response = $this->callListenerReq($listener, 'http://localhost/lala/foo/lala', true);
         $this->assertSame('https://localhost/lala/foo/lala', $response->headers->get('Location'));
 
-        $response = $this->callListenerReq($listener, '/lala/abarb', true);
+        $response = $this->callListenerReq($listener, 'https://localhost/lala/abarb', true);
         $this->assertSame(null, $response);
     }
 
@@ -86,9 +86,9 @@ class ForcedSslListenerTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('https://test.example.org/foo/lala', $response->headers->get('Location'));
     }
 
-    protected function callListenerReq($listener, $path, $masterReq)
+    protected function callListenerReq($listener, $uri, $masterReq)
     {
-        $request = Request::create($path);
+        $request = Request::create($uri);
 
         $event = new GetResponseEvent($this->kernel, $request, $masterReq ? HttpKernelInterface::MASTER_REQUEST : HttpKernelInterface::SUB_REQUEST);
         $listener->onKernelRequest($event);
@@ -96,9 +96,9 @@ class ForcedSslListenerTest extends \PHPUnit_Framework_TestCase
         return $event->getResponse();
     }
 
-    protected function callListenerResp($listener, $path, $masterReq)
+    protected function callListenerResp(ForcedSslListener $listener, $uri, $masterReq)
     {
-        $request = Request::create($path);
+        $request = Request::create($uri);
         $response = new Response();
 
         $event = new FilterResponseEvent($this->kernel, $request, $masterReq ? HttpKernelInterface::MASTER_REQUEST : HttpKernelInterface::SUB_REQUEST, $response);


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | "master" |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #147 |
| License | MIT |
