### PR TITLE
Ensure intentionally prefixed external urls to pass through filters

### DIFF
--- a/EventListener/ExternalRedirectListener.php
+++ b/EventListener/ExternalRedirectListener.php
@@ -109,6 +109,9 @@ class ExternalRedirectListener
 
     public function isExternalRedirect($source, $target)
     {
+        // cleanup "\rhttp://foo.com/" and other null prefixeds to be scanned as valid internal redirect
+        $target = trim($target); 
+
         // handle protocol-relative URLs that parse_url() doesn't like
         if (substr($target, 0, 2) === '//') {
             $target = 'proto:'.$target;

--- a/Tests/Listener/ExternalRedirectListenerTest.php
+++ b/Tests/Listener/ExternalRedirectListenerTest.php
@@ -52,6 +52,9 @@ class ExternalRedirectListenerTest extends \PHPUnit_Framework_TestCase
             array('http://test.org/', 'http://test.org.com/', true),
             array('http://test.org/', 'http://foo.com/http://test.org/', true),
             array('http://test.org/', '//foo.com/', true),
+            array('http://test.org/', "\r".'http://foo.com/', true),
+            array('http://test.org/', "\0\0".'http://foo.com/', true),
+            array('http://test.org/', "  ".'http://foo.com/', true),
         );
     }
 


### PR DESCRIPTION
Seams like url like "\nhttp://www.google.fr" or "\0http://www.google.fr", pass through the external redirect filter, because parse_url() parse the host as path instead of host+protocol.

```
ExternalRedirectListener.php on line 76:
"\rhttp://www.google.fr?foo=1"
```

parse url =>

```
ExternalRedirectListener.php on line 127:
array:2 [▼
  "path" => "_http://www.google.fr"
  "query" => "foo=1"
]
```

If I provide url in query params like "/my/route?redirect=%0Dhttp://badwebsite.com", you can pass through the external redirect filter.

Maybe just providing a trim($url) like in this PR can fix the majority of the issues.
