### PR TITLE
Forced SSL configurable redirect status code

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -143,6 +143,7 @@ class Configuration implements ConfigurationInterface
                             ->prototype('scalar')->end()
                             ->defaultValue(array())
                         ->end()
+                        ->scalarNode('redirect_status_code')->defaultValue(302)->end()
                     ->end()
                 ->end()
 

--- a/DependencyInjection/NelmioSecurityExtension.php
+++ b/DependencyInjection/NelmioSecurityExtension.php
@@ -173,6 +173,7 @@ class NelmioSecurityExtension extends Extension
             $container->setParameter('nelmio_security.forced_ssl.hsts_preload', $config['forced_ssl']['hsts_preload']);
             $container->setParameter('nelmio_security.forced_ssl.whitelist', $config['forced_ssl']['whitelist']);
             $container->setParameter('nelmio_security.forced_ssl.hosts', $config['forced_ssl']['hosts']);
+            $container->setParameter('nelmio_security.forced_ssl.redirect_status_code', $config['forced_ssl']['redirect_status_code']);
         }
 
         if (!empty($config['referrer_policy']) && $config['referrer_policy']['enabled']) {

--- a/EventListener/ForcedSslListener.php
+++ b/EventListener/ForcedSslListener.php
@@ -23,14 +23,16 @@ class ForcedSslListener
     private $hstsPreload;
     private $whitelist;
     private $hosts;
+    private $redirectStatusCode;
 
-    public function __construct($hstsMaxAge, $hstsSubdomains, $hstsPreload = false, array $whitelist = array(), array $hosts = array())
+    public function __construct($hstsMaxAge, $hstsSubdomains, $hstsPreload = false, array $whitelist = array(), array $hosts = array(), $redirectStatusCode = 302)
     {
         $this->hstsMaxAge = $hstsMaxAge;
         $this->hstsSubdomains = $hstsSubdomains;
         $this->hstsPreload = $hstsPreload;
         $this->whitelist = $whitelist ? '('.implode('|', $whitelist).')' : null;
         $this->hosts = $hosts ? '('.implode('|', $hosts).')' : null;
+        $this->redirectStatusCode = $redirectStatusCode;
     }
 
     public function onKernelRequest(GetResponseEvent $e)
@@ -57,7 +59,7 @@ class ForcedSslListener
         }
 
         // redirect the rest to SSL
-        $e->setResponse(new RedirectResponse('https://'.substr($request->getUri(), 7)));
+        $e->setResponse(new RedirectResponse('https://'.substr($request->getUri(), 7), $this->redirectStatusCode));
     }
 
     public function onKernelResponse(FilterResponseEvent $e)

--- a/Resources/config/forced_ssl.yml
+++ b/Resources/config/forced_ssl.yml
@@ -7,5 +7,6 @@ services:
             - '%nelmio_security.forced_ssl.hsts_preload%'
             - '%nelmio_security.forced_ssl.whitelist%'
             - '%nelmio_security.forced_ssl.hosts%'
+            - '%nelmio_security.forced_ssl.redirect_status_code%'
         tags:
             - { name: kernel.event_listener, event: kernel.request, method: onKernelRequest, priority: 30000 }

--- a/Tests/Listener/ForcedSslListenerTest.php
+++ b/Tests/Listener/ForcedSslListenerTest.php
@@ -86,6 +86,19 @@ class ForcedSslListenerTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('https://test.example.org/foo/lala', $response->headers->get('Location'));
     }
 
+    public function testForcedSslRedirectStatusCodes()
+    {
+        $listener = new ForcedSslListener(null, false);
+
+        $response = $this->callListenerReq($listener, '/foo/lala', true);
+        $this->assertSame(302, $response->getStatusCode());
+
+        $listener = new ForcedSslListener(null, false, false, array(), array(), 301);
+
+        $response = $this->callListenerReq($listener, '/foo/lala', true);
+        $this->assertSame(301, $response->getStatusCode());
+    }
+
     protected function callListenerReq($listener, $path, $masterReq)
     {
         $request = Request::create($path);


### PR DESCRIPTION
Before this PR the bundle always used the default http status code `302` of the `Symfony\Component\HttpFoundation\RedirectResponse` class.

This PR adds the possibility to change that status code to something else, like so:

```
nelmio_security:
    forced_ssl:
        redirect_status_code: 301
```
