### PR TITLE
Use request URI instead of path info

### DIFF
--- a/EventListener/ClickjackingListener.php
+++ b/EventListener/ClickjackingListener.php
@@ -46,7 +46,7 @@ class ClickjackingListener extends AbstractContentTypeRestrictableListener
             return;
         }
 
-        $currentPath = $e->getRequest()->getPathInfo() ?: '/';
+        $currentPath = $e->getRequest()->getRequestUri() ?: '/';
 
         foreach ($this->paths as $path => $options) {
             if (preg_match('{'.$path.'}i', $currentPath)) {

--- a/Tests/Listener/ClickjackingListenerTest.php
+++ b/Tests/Listener/ClickjackingListenerTest.php
@@ -28,6 +28,7 @@ class ClickjackingListenerTest extends \PHPUnit_Framework_TestCase
         $this->listener = new ClickjackingListener(array(
             '^/frames/' => array('header' => 'ALLOW'),
             '/frames/' => array('header' => 'SAMEORIGIN'),
+            '^.*\?[^\?]*foo=bar' => array('header' => 'ALLOW'),
             '/this/allow' => array('header' => 'ALLOW-FROM http://biz.domain.com'),
             '^/.*' => array('header' => 'DENY'),
             '.*' => array('header' => 'ALLOW'),
@@ -49,6 +50,8 @@ class ClickjackingListenerTest extends \PHPUnit_Framework_TestCase
             array('', 'DENY'),
             array('/', 'DENY'),
             array('/test', 'DENY'),
+            array('/path?test&foo=bar&another', null),
+            array('/path?foo=bar', null),
             array('/frames/foo', null),
             array('/this/allow', 'ALLOW-FROM http://biz.domain.com'),
             array('/sub/frames/foo', 'SAMEORIGIN'),
@@ -74,7 +77,7 @@ class ClickjackingListenerTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @dataProvider provideContentTypeForrestrictions
+     * @dataProvider provideContentTypeForRestrictions
      */
     public function testClickjackingWithContentTypes($contentType, $result)
     {
@@ -89,7 +92,7 @@ class ClickjackingListenerTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($result, $response->headers->get('X-Frame-Options'));
     }
 
-    public function provideContentTypeForrestrictions()
+    public function provideContentTypeForRestrictions()
     {
         return array(
             array('application/json', null),


### PR DESCRIPTION
Allows matching the query parameter for clickjacking protection.