### PR TITLE
Abort CSP compiler pass when CSP is not enabled

### DIFF
--- a/DependencyInjection/Compiler/CspReportFilterCompilerPass.php
+++ b/DependencyInjection/Compiler/CspReportFilterCompilerPass.php
@@ -10,6 +10,10 @@ class CspReportFilterCompilerPass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container)
     {
+        if (!$container->hasDefinition('nelmio_security.csp_report.filter')) {
+            return;
+        }
+        
         $services = $container->findTaggedServiceIds('nelmio_security.csp_report_filter');
 
         $cspViolationLogFilterDefinition = $container->getDefinition('nelmio_security.csp_report.filter');

--- a/Tests/DependencyInjection/CspReportFilterCompilerPassTest.php
+++ b/Tests/DependencyInjection/CspReportFilterCompilerPassTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Nelmio\Tests\SecurityBundle\DependencyInjection\Compiler;
+
+use Nelmio\SecurityBundle\DependencyInjection\Compiler\CspReportFilterCompilerPass;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
+
+class CspReportFilterCompilerPassTest extends TestCase
+{
+    public function testNoExceptionIsThrownWhenCspReportFilterServiceDoesNotExist()
+    {
+        $builder = new ContainerBuilder();
+
+        $compilerPass = new CspReportFilterCompilerPass();
+        $compilerPass->process($builder);
+
+        $this->assertFalse($builder->has('nelmio_security.csp_report.filter'));
+    }
+
+    public function testAddMethodCallsToCspReportFilter()
+    {
+        $builder = new ContainerBuilder();
+
+        $noiseDetectorDefinition = new Definition(
+            'Nelmio\SecurityBundle\ContentSecurityPolicy\Violation\Filter\CustomRulesNoiseDetector'
+        );
+        $noiseDetectorDefinition->addTag('nelmio_security.csp_report_filter');
+
+        $builder->addDefinitions(array(
+            'nelmio_security.csp_report.filter' => new Definition(
+                'Nelmio\SecurityBundle\ContentSecurityPolicy\Violation\Filter\Filter'
+            ),
+            'nelmio_security.noise_detector' => $noiseDetectorDefinition
+        ));
+
+        $compilerPass = new CspReportFilterCompilerPass();
+        $compilerPass->process($builder);
+
+        $methodCalls = $builder->getDefinition('nelmio_security.csp_report.filter')->getMethodCalls();
+
+        $this->assertCount(1, $methodCalls);
+
+        $this->assertEquals('addNoiseDetector', $methodCalls[0][0]);
+        $this->assertEquals(new Reference('nelmio_security.noise_detector'), $methodCalls[0][1][0]);
+    }
+}


### PR DESCRIPTION
When csp enabled is set to false in the configuration csp.xml will not be loaded,
so there is no service `nelmio_security.csp_report.filter` and asking the definition
for that non-existing service results in an exception.

So first we check if the service is available in the container and if it's not we bail out
(return early).

Fixes https://github.com/nelmio/NelmioSecurityBundle/issues/174