### PR TITLE
Support random_compat v9.99.99

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         }
     ],
     "require": {
-        "paragonie/random_compat": "~1.0|~2.0",
+        "paragonie/random_compat": "~1.0|~2.0|9.99.99",
         "symfony/framework-bundle": "~2.3|~3.0|~4.0",
         "symfony/security": "~2.3|~3.0|~4.0",
         "ua-parser/uap-php": "^3.4.4"


### PR DESCRIPTION
v9.99.99 of random_compat is a no-op library specifically for PHP7.