### PR TITLE
Don't ship unneeded files for composer installs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+/.gitattributes export-ignore
+/.gitignore export-ignore
+/.travis.yml export-ignore
+/phpunit.xml.dist export-ignore
+/Tests export-ignore


### PR DESCRIPTION
This PR adds `.gitattributes`, which can be used to control which files are being shipped with distribution installs via Composer.

This will prevent Composer from downloading files which are not needed when used as a dependencies: CI files and tests.