### PR TITLE
Allow configuring a report URI for XSS

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -174,6 +174,7 @@ class Configuration implements ConfigurationInterface
                     ->children()
                         ->booleanNode('enabled')->defaultFalse()->end()
                         ->booleanNode('mode_block')->defaultFalse()->end()
+                        ->scalarNode('report_uri')->defaultNull()->end()
                     ->end()
                 ->end()
 

--- a/EventListener/XssProtectionListener.php
+++ b/EventListener/XssProtectionListener.php
@@ -20,11 +20,13 @@ class XssProtectionListener implements EventSubscriberInterface
 {
     private $enabled;
     private $modeBlock;
+    private $reportUri;
 
-    public function __construct($enabled, $modeBlock)
+    public function __construct($enabled, $modeBlock, $reportUri = null)
     {
         $this->enabled = $enabled;
         $this->modeBlock = $modeBlock;
+        $this->reportUri = $reportUri;
     }
 
     public function onKernelResponse(FilterResponseEvent $e)
@@ -39,14 +41,17 @@ class XssProtectionListener implements EventSubscriberInterface
             return;
         }
 
+        $value = '0';
         if ($this->enabled) {
+            $value = '1';
+
             if ($this->modeBlock) {
-                $value = '1; mode=block';
-            } else {
-                $value = '1';
+                $value .= '; mode=block';
             }
-        } else {
-            $value = '0';
+        }
+
+        if ($this->reportUri) {
+            $value .= '; report=' . $this->reportUri;
         }
 
         $response->headers->set('X-XSS-Protection', $value);
@@ -61,7 +66,8 @@ class XssProtectionListener implements EventSubscriberInterface
     {
         $enabled = $config['enabled'];
         $modeBlock = $config['mode_block'];
+        $reportUri = $config['report_uri'];
 
-        return new self($enabled, $modeBlock);
+        return new self($enabled, $modeBlock, $reportUri);
     }
 }

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -132,6 +132,16 @@ class ConfigurationTest extends \PHPUnit\Framework\TestCase
         );
     }
 
+    public function testXssProtection()
+    {
+        $this->processYamlConfiguration(
+            "xss_protection:\n".
+            "  enabled: true\n".
+            "  mode_block: true\n".
+            "  report_uri: https://report.com/endpoint\n"
+        );
+    }
+
     private function processYamlConfiguration($config)
     {
         $parser = new Parser();

--- a/Tests/Listener/XssProtectionListenerTest.php
+++ b/Tests/Listener/XssProtectionListenerTest.php
@@ -34,6 +34,7 @@ class XssProtectionListenerTest extends \PHPUnit\Framework\TestCase
             array('1', new XssProtectionListener(true, false)),
             array('0', new XssProtectionListener(false, true)),
             array('1; mode=block', new XssProtectionListener(true, true)),
+            array('1; mode=block; report=https://report.com/endpoint', new XssProtectionListener(true, true, 'https://report.com/endpoint')),
         );
     }
 


### PR DESCRIPTION
`X-XSS-Protection` supports specifying a reporting endpoint. See https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-XSS-Protection