### PR TITLE
Use base64 for encoding

### DIFF
--- a/ContentSecurityPolicy/NonceGenerator.php
+++ b/ContentSecurityPolicy/NonceGenerator.php
@@ -30,6 +30,6 @@ class NonceGenerator
      */
     public function generate()
     {
-        return bin2hex(random_bytes($this->numberOfBytes));
+        return base64_encode(random_bytes($this->numberOfBytes));
     }
 }


### PR DESCRIPTION
This is how the standard defines the nonce

```
; Nonces: 'nonce-[nonce goes here]'
nonce-source  = "'nonce-" base64-value "'"
base64-value  = 1*( ALPHA / DIGIT / "+" / "/" / "-" / "_" )*2( "=" )
```

So let’s use base64 for nonce encoding.