### PR TITLE
Referrer Policies should not be concatenated

### DIFF
--- a/EventListener/ReferrerPolicyListener.php
+++ b/EventListener/ReferrerPolicyListener.php
@@ -36,6 +36,6 @@ class ReferrerPolicyListener
 
         $response = $e->getResponse();
 
-        $response->headers->set('Referrer-Policy', implode(', ', $this->policies));
+        $response->headers->set('Referrer-Policy', $this->policies);
     }
 }

--- a/Tests/Listener/ReferrerPolicyListenerTest.php
+++ b/Tests/Listener/ReferrerPolicyListenerTest.php
@@ -33,16 +33,16 @@ class ReferrerPolicyListenerTest extends \PHPUnit\Framework\TestCase
     {
         $response = $this->callListener($listener, '/', true);
 
-        $this->assertEquals($expectedValue, $response->headers->get('Referrer-Policy'));
+        $this->assertEquals($expectedValue, $response->headers->get('Referrer-Policy', null, false));
     }
 
     public function provideVariousConfigs()
     {
         return array(
-            array('', new ReferrerPolicyListener(array())),
-            array('no-referrer', new ReferrerPolicyListener(array('no-referrer'))),
-            array('no-referrer, strict-origin-when-cross-origin', new ReferrerPolicyListener(array('no-referrer', 'strict-origin-when-cross-origin'))),
-            array('no-referrer, no-referrer-when-downgrade, strict-origin-when-cross-origin', new ReferrerPolicyListener(array('no-referrer', 'no-referrer-when-downgrade', 'strict-origin-when-cross-origin'))),
+            array(array(), new ReferrerPolicyListener(array())),
+            array(array('no-referrer'), new ReferrerPolicyListener(array('no-referrer'))),
+            array(array('no-referrer', 'strict-origin-when-cross-origin'), new ReferrerPolicyListener(array('no-referrer', 'strict-origin-when-cross-origin'))),
+            array(array('no-referrer', 'no-referrer-when-downgrade', 'strict-origin-when-cross-origin'), new ReferrerPolicyListener(array('no-referrer', 'no-referrer-when-downgrade', 'strict-origin-when-cross-origin'))),
         );
     }
 


### PR DESCRIPTION
Per the [main spec](https://www.w3.org/TR/referrer-policy/) (and a number of validators currently yelling at us) the value of `Referrer-Policy` is an enum.  This bundle currently concatenates multiple values together, violating the enum, so instead multiple valid headers should be sent.