### PR TITLE
Fixed deprecated/invalid method usage on logger interface

### DIFF
--- a/EventListener/ExternalRedirectListener.php
+++ b/EventListener/ExternalRedirectListener.php
@@ -78,7 +78,7 @@ class ExternalRedirectListener
         }
 
         if ($this->logger) {
-            $this->logger->warn('External redirect detected from '.$e->getRequest()->getUri().' to '.$response->headers->get('Location'));
+            $this->logger->warning('External redirect detected from '.$e->getRequest()->getUri().' to '.$response->headers->get('Location'));
         }
 
         if ($this->abort) {

--- a/Session/CookieSessionHandler.php
+++ b/Session/CookieSessionHandler.php
@@ -143,7 +143,7 @@ class CookieSessionHandler implements \SessionHandlerInterface
     {
         if (!$this->request) {
             if ($this->logger) {
-                $this->logger->crit('CookieSessionHandler::open - The Request object is missing');
+                $this->logger->critical('CookieSessionHandler::open - The Request object is missing');
             }
 
             throw new \RuntimeException('You cannot access the session without a Request object set');
@@ -163,7 +163,7 @@ class CookieSessionHandler implements \SessionHandlerInterface
     {
         if (!$this->request) {
             if ($this->logger) {
-                $this->logger->crit('CookieSessionHandler::read - The Request object is missing');
+                $this->logger->critical('CookieSessionHandler::read - The Request object is missing');
             }
 
             throw new \RuntimeException('You cannot access the session without a Request object set');


### PR DESCRIPTION
I don't know if it was left out or what but I guess this was incorrect use of logger interface. I mean, these classes typehint `Psr\Log\LoggerInterface` so there are no `warn` or `crit` methods there, they were in Symfony's bridge. But the typehint is for PSR so... it should be `warning` and `critical`, right?