### PR TITLE
Add Symfony 5 to the long list of supported versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### To release
 
   * Symfony 5 compatibility added
+  * Bump minimal Twig version to 1.38.0
 
 ### 2.8.0 (2020-03-02)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### To release
+
+  * Symfony 5 compatibility added
+
 ### 2.8.0 (2020-03-02)
 
   * Fixed deprecated/invalid method usage on logger interface

--- a/EventListener/ClickjackingListener.php
+++ b/EventListener/ClickjackingListener.php
@@ -12,6 +12,7 @@
 namespace Nelmio\SecurityBundle\EventListener;
 
 use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpKernel\KernelEvents;
 
@@ -30,8 +31,16 @@ class ClickjackingListener extends AbstractContentTypeRestrictableListener
         return array(KernelEvents::RESPONSE => 'onKernelResponse');
     }
 
-    public function onKernelResponse(FilterResponseEvent $e)
+    /**
+     * @param FilterResponseEvent|ResponseEvent $e
+     */
+    public function onKernelResponse($e)
     {
+        // Compatibility with Symfony < 5 and Symfony >=5
+        if (!$e instanceof FilterResponseEvent && !$e instanceof ResponseEvent) {
+            return;
+        }
+
         if (HttpKernelInterface::MASTER_REQUEST !== $e->getRequestType()) {
             return;
         }

--- a/EventListener/ClickjackingListener.php
+++ b/EventListener/ClickjackingListener.php
@@ -16,6 +16,9 @@ use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpKernel\KernelEvents;
 
+/**
+ * @final
+ */
 class ClickjackingListener extends AbstractContentTypeRestrictableListener
 {
     private $paths;

--- a/EventListener/ClickjackingListener.php
+++ b/EventListener/ClickjackingListener.php
@@ -38,7 +38,7 @@ class ClickjackingListener extends AbstractContentTypeRestrictableListener
     {
         // Compatibility with Symfony < 5 and Symfony >=5
         if (!$e instanceof FilterResponseEvent && !$e instanceof ResponseEvent) {
-            return;
+            throw new \InvalidArgumentException(\sprintf('Expected instance of type %s, %s given', \class_exists(ResponseEvent::class) ? ResponseEvent::class : FilterResponseEvent::class, \is_object($e) ? \get_class($e) : \gettype($e)));
         }
 
         if (HttpKernelInterface::MASTER_REQUEST !== $e->getRequestType()) {

--- a/EventListener/ContentSecurityPolicyListener.php
+++ b/EventListener/ContentSecurityPolicyListener.php
@@ -22,6 +22,9 @@ use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpKernel\KernelEvents;
 use Nelmio\SecurityBundle\ContentSecurityPolicy\DirectiveSet;
 
+/**
+ * @final
+ */
 class ContentSecurityPolicyListener extends AbstractContentTypeRestrictableListener
 {
     protected $report;

--- a/EventListener/ContentSecurityPolicyListener.php
+++ b/EventListener/ContentSecurityPolicyListener.php
@@ -53,7 +53,7 @@ class ContentSecurityPolicyListener extends AbstractContentTypeRestrictableListe
     {
         // Compatibility with Symfony < 5 and Symfony >=5
         if (!$e instanceof GetResponseEvent && !$e instanceof RequestEvent) {
-            return;
+            throw new \InvalidArgumentException(\sprintf('Expected instance of type %s, %s given', \class_exists(RequestEvent::class) ? RequestEvent::class : GetResponseEvent::class, \is_object($e) ? \get_class($e) : \gettype($e)));
         }
 
         if ($e->getRequestType() !== HttpKernelInterface::MASTER_REQUEST) {
@@ -141,7 +141,7 @@ class ContentSecurityPolicyListener extends AbstractContentTypeRestrictableListe
     {
         // Compatibility with Symfony < 5 and Symfony >=5
         if (!$e instanceof FilterResponseEvent && !$e instanceof ResponseEvent) {
-            return;
+            throw new \InvalidArgumentException(\sprintf('Expected instance of type %s, %s given', \class_exists(ResponseEvent::class) ? ResponseEvent::class : FilterResponseEvent::class, \is_object($e) ? \get_class($e) : \gettype($e)));
         }
 
         if (HttpKernelInterface::MASTER_REQUEST !== $e->getRequestType()) {

--- a/EventListener/ContentTypeListener.php
+++ b/EventListener/ContentTypeListener.php
@@ -12,6 +12,7 @@
 namespace Nelmio\SecurityBundle\EventListener;
 
 use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 
 class ContentTypeListener
@@ -23,8 +24,16 @@ class ContentTypeListener
         $this->nosniff = $nosniff;
     }
 
-    public function onKernelResponse(FilterResponseEvent $e)
+    /**
+     * @param FilterResponseEvent|ResponseEvent $e
+     */
+    public function onKernelResponse($e)
     {
+        // Compatibility with Symfony < 5 and Symfony >=5
+        if (!$e instanceof FilterResponseEvent && !$e instanceof ResponseEvent) {
+            return;
+        }
+
         if (HttpKernelInterface::MASTER_REQUEST !== $e->getRequestType()) {
             return;
         }

--- a/EventListener/ContentTypeListener.php
+++ b/EventListener/ContentTypeListener.php
@@ -15,6 +15,9 @@ use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
 use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 
+/**
+ * @final
+ */
 class ContentTypeListener
 {
     protected $nosniff;

--- a/EventListener/ContentTypeListener.php
+++ b/EventListener/ContentTypeListener.php
@@ -31,7 +31,7 @@ class ContentTypeListener
     {
         // Compatibility with Symfony < 5 and Symfony >=5
         if (!$e instanceof FilterResponseEvent && !$e instanceof ResponseEvent) {
-            return;
+            throw new \InvalidArgumentException(\sprintf('Expected instance of type %s, %s given', \class_exists(ResponseEvent::class) ? ResponseEvent::class : FilterResponseEvent::class, \is_object($e) ? \get_class($e) : \gettype($e)));
         }
 
         if (HttpKernelInterface::MASTER_REQUEST !== $e->getRequestType()) {

--- a/EventListener/EncryptedCookieListener.php
+++ b/EventListener/EncryptedCookieListener.php
@@ -14,7 +14,9 @@ namespace Nelmio\SecurityBundle\EventListener;
 use Nelmio\SecurityBundle\Encrypter;
 use Symfony\Component\HttpFoundation\Cookie;
 use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 
 class EncryptedCookieListener
@@ -32,8 +34,16 @@ class EncryptedCookieListener
         }
     }
 
-    public function onKernelRequest(GetResponseEvent $e)
+    /**
+     * @param GetResponseEvent|RequestEvent $e
+     */
+    public function onKernelRequest($e)
     {
+        // Compatibility with Symfony < 5 and Symfony >=5
+        if (!$e instanceof GetResponseEvent && !$e instanceof RequestEvent) {
+            return;
+        }
+
         if (HttpKernelInterface::MASTER_REQUEST !== $e->getRequestType()) {
             return;
         }
@@ -53,8 +63,16 @@ class EncryptedCookieListener
         }
     }
 
-    public function onKernelResponse(FilterResponseEvent $e)
+    /**
+     * @param FilterResponseEvent|ResponseEvent $e
+     */
+    public function onKernelResponse($e)
     {
+        // Compatibility with Symfony < 5 and Symfony >=5
+        if (!$e instanceof FilterResponseEvent && !$e instanceof ResponseEvent) {
+            return;
+        }
+
         if (HttpKernelInterface::MASTER_REQUEST !== $e->getRequestType()) {
             return;
         }

--- a/EventListener/EncryptedCookieListener.php
+++ b/EventListener/EncryptedCookieListener.php
@@ -41,7 +41,7 @@ class EncryptedCookieListener
     {
         // Compatibility with Symfony < 5 and Symfony >=5
         if (!$e instanceof GetResponseEvent && !$e instanceof RequestEvent) {
-            return;
+            throw new \InvalidArgumentException(\sprintf('Expected instance of type %s, %s given', \class_exists(RequestEvent::class) ? RequestEvent::class : GetResponseEvent::class, \is_object($e) ? \get_class($e) : \gettype($e)));
         }
 
         if (HttpKernelInterface::MASTER_REQUEST !== $e->getRequestType()) {
@@ -70,7 +70,7 @@ class EncryptedCookieListener
     {
         // Compatibility with Symfony < 5 and Symfony >=5
         if (!$e instanceof FilterResponseEvent && !$e instanceof ResponseEvent) {
-            return;
+            throw new \InvalidArgumentException(\sprintf('Expected instance of type %s, %s given', \class_exists(ResponseEvent::class) ? ResponseEvent::class : FilterResponseEvent::class, \is_object($e) ? \get_class($e) : \gettype($e)));
         }
 
         if (HttpKernelInterface::MASTER_REQUEST !== $e->getRequestType()) {

--- a/EventListener/EncryptedCookieListener.php
+++ b/EventListener/EncryptedCookieListener.php
@@ -19,6 +19,9 @@ use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 
+/**
+ * @final
+ */
 class EncryptedCookieListener
 {
     private $encrypter;

--- a/EventListener/ExternalRedirectListener.php
+++ b/EventListener/ExternalRedirectListener.php
@@ -14,6 +14,7 @@ namespace Nelmio\SecurityBundle\EventListener;
 use Nelmio\SecurityBundle\ExternalRedirect\TargetValidator;
 use Nelmio\SecurityBundle\ExternalRedirect\WhitelistBasedTargetValidator;
 use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpKernel\Exception\HttpException;
@@ -56,8 +57,16 @@ class ExternalRedirectListener
         $this->generator = $generator;
     }
 
-    public function onKernelResponse(FilterResponseEvent $e)
+    /**
+     * @param FilterResponseEvent|ResponseEvent $e
+     */
+    public function onKernelResponse($e)
     {
+        // Compatibility with Symfony < 5 and Symfony >=5
+        if (!$e instanceof FilterResponseEvent && !$e instanceof ResponseEvent) {
+            return;
+        }
+
         if (HttpKernelInterface::MASTER_REQUEST !== $e->getRequestType()) {
             return;
         }

--- a/EventListener/ExternalRedirectListener.php
+++ b/EventListener/ExternalRedirectListener.php
@@ -64,7 +64,7 @@ class ExternalRedirectListener
     {
         // Compatibility with Symfony < 5 and Symfony >=5
         if (!$e instanceof FilterResponseEvent && !$e instanceof ResponseEvent) {
-            return;
+            throw new \InvalidArgumentException(\sprintf('Expected instance of type %s, %s given', \class_exists(ResponseEvent::class) ? ResponseEvent::class : FilterResponseEvent::class, \is_object($e) ? \get_class($e) : \gettype($e)));
         }
 
         if (HttpKernelInterface::MASTER_REQUEST !== $e->getRequestType()) {

--- a/EventListener/ExternalRedirectListener.php
+++ b/EventListener/ExternalRedirectListener.php
@@ -20,6 +20,9 @@ use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
+/**
+ * @final
+ */
 class ExternalRedirectListener
 {
     private $abort;

--- a/EventListener/FlexibleSslListener.php
+++ b/EventListener/FlexibleSslListener.php
@@ -16,7 +16,9 @@ use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Cookie;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\Security\Http\Event\InteractiveLoginEvent;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
@@ -36,8 +38,16 @@ class FlexibleSslListener implements LogoutHandlerInterface
         $this->dispatcher = $dispatcher;
     }
 
-    public function onKernelRequest(GetResponseEvent $e)
+    /**
+     * @param GetResponseEvent|RequestEvent $e
+     */
+    public function onKernelRequest($e)
     {
+        // Compatibility with Symfony < 5 and Symfony >=5
+        if (!$e instanceof GetResponseEvent && !$e instanceof RequestEvent) {
+            return;
+        }
+
         if (HttpKernelInterface::MASTER_REQUEST !== $e->getRequestType()) {
             return;
         }
@@ -55,8 +65,16 @@ class FlexibleSslListener implements LogoutHandlerInterface
         $this->dispatcher->addListener('kernel.response', array($this, 'onPostLoginKernelResponse'), -1000);
     }
 
-    public function onPostLoginKernelResponse(FilterResponseEvent $e)
+    /**
+     * @param FilterResponseEvent|ResponseEvent $e
+     */
+    public function onPostLoginKernelResponse($e)
     {
+        // Compatibility with Symfony < 5 and Symfony >=5
+        if (!$e instanceof FilterResponseEvent && !$e instanceof ResponseEvent) {
+            return;
+        }
+
         if (HttpKernelInterface::MASTER_REQUEST !== $e->getRequestType()) {
             return;
         }

--- a/EventListener/FlexibleSslListener.php
+++ b/EventListener/FlexibleSslListener.php
@@ -25,6 +25,9 @@ use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Http\Logout\LogoutHandlerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
+/**
+ * @final
+ */
 class FlexibleSslListener implements LogoutHandlerInterface
 {
     private $cookieName;

--- a/EventListener/FlexibleSslListener.php
+++ b/EventListener/FlexibleSslListener.php
@@ -45,7 +45,7 @@ class FlexibleSslListener implements LogoutHandlerInterface
     {
         // Compatibility with Symfony < 5 and Symfony >=5
         if (!$e instanceof GetResponseEvent && !$e instanceof RequestEvent) {
-            return;
+            throw new \InvalidArgumentException(\sprintf('Expected instance of type %s, %s given', \class_exists(RequestEvent::class) ? RequestEvent::class : GetResponseEvent::class, \is_object($e) ? \get_class($e) : \gettype($e)));
         }
 
         if (HttpKernelInterface::MASTER_REQUEST !== $e->getRequestType()) {
@@ -72,7 +72,7 @@ class FlexibleSslListener implements LogoutHandlerInterface
     {
         // Compatibility with Symfony < 5 and Symfony >=5
         if (!$e instanceof FilterResponseEvent && !$e instanceof ResponseEvent) {
-            return;
+            throw new \InvalidArgumentException(\sprintf('Expected instance of type %s, %s given', \class_exists(ResponseEvent::class) ? ResponseEvent::class : FilterResponseEvent::class, \is_object($e) ? \get_class($e) : \gettype($e)));
         }
 
         if (HttpKernelInterface::MASTER_REQUEST !== $e->getRequestType()) {

--- a/EventListener/ForcedSslListener.php
+++ b/EventListener/ForcedSslListener.php
@@ -13,7 +13,9 @@ namespace Nelmio\SecurityBundle\EventListener;
 
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 
 class ForcedSslListener
@@ -35,8 +37,16 @@ class ForcedSslListener
         $this->redirectStatusCode = $redirectStatusCode;
     }
 
-    public function onKernelRequest(GetResponseEvent $e)
+    /**
+     * @param GetResponseEvent|RequestEvent $e
+     */
+    public function onKernelRequest($e)
     {
+        // Compatibility with Symfony < 5 and Symfony >=5
+        if (!$e instanceof GetResponseEvent && !$e instanceof RequestEvent) {
+            return;
+        }
+
         if (HttpKernelInterface::MASTER_REQUEST !== $e->getRequestType()) {
             return;
         }
@@ -62,8 +72,16 @@ class ForcedSslListener
         $e->setResponse(new RedirectResponse('https://'.substr($request->getUri(), 7), $this->redirectStatusCode));
     }
 
-    public function onKernelResponse(FilterResponseEvent $e)
+    /**
+     * @param FilterResponseEvent|ResponseEvent $e
+     */
+    public function onKernelResponse($e)
     {
+        // Compatibility with Symfony < 5 and Symfony >=5
+        if (!$e instanceof FilterResponseEvent && !$e instanceof ResponseEvent) {
+            return;
+        }
+
         if (HttpKernelInterface::MASTER_REQUEST !== $e->getRequestType()) {
             return;
         }

--- a/EventListener/ForcedSslListener.php
+++ b/EventListener/ForcedSslListener.php
@@ -54,7 +54,7 @@ class ForcedSslListener
         $request = $e->getRequest();
 
         // skip SSL & non-GET/HEAD requests
-        if ($request->isSecure() || !$request->isMethodSafe(false)) {
+        if ($request->isSecure() || !$request->isMethodSafe()) {
             return;
         }
 

--- a/EventListener/ForcedSslListener.php
+++ b/EventListener/ForcedSslListener.php
@@ -18,6 +18,9 @@ use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 
+/**
+ * @final
+ */
 class ForcedSslListener
 {
     private $hstsMaxAge;

--- a/EventListener/ForcedSslListener.php
+++ b/EventListener/ForcedSslListener.php
@@ -44,7 +44,7 @@ class ForcedSslListener
     {
         // Compatibility with Symfony < 5 and Symfony >=5
         if (!$e instanceof GetResponseEvent && !$e instanceof RequestEvent) {
-            return;
+            throw new \InvalidArgumentException(\sprintf('Expected instance of type %s, %s given', \class_exists(RequestEvent::class) ? RequestEvent::class : GetResponseEvent::class, \is_object($e) ? \get_class($e) : \gettype($e)));
         }
 
         if (HttpKernelInterface::MASTER_REQUEST !== $e->getRequestType()) {
@@ -79,7 +79,7 @@ class ForcedSslListener
     {
         // Compatibility with Symfony < 5 and Symfony >=5
         if (!$e instanceof FilterResponseEvent && !$e instanceof ResponseEvent) {
-            return;
+            throw new \InvalidArgumentException(\sprintf('Expected instance of type %s, %s given', \class_exists(ResponseEvent::class) ? ResponseEvent::class : FilterResponseEvent::class, \is_object($e) ? \get_class($e) : \gettype($e)));
         }
 
         if (HttpKernelInterface::MASTER_REQUEST !== $e->getRequestType()) {

--- a/EventListener/ReferrerPolicyListener.php
+++ b/EventListener/ReferrerPolicyListener.php
@@ -12,6 +12,7 @@
 namespace Nelmio\SecurityBundle\EventListener;
 
 use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 
 /**
@@ -28,8 +29,16 @@ class ReferrerPolicyListener
         $this->policies = $policies;
     }
 
-    public function onKernelResponse(FilterResponseEvent $e)
+    /**
+     * @param FilterResponseEvent|ResponseEvent $e
+     */
+    public function onKernelResponse($e)
     {
+        // Compatibility with Symfony < 5 and Symfony >=5
+        if (!$e instanceof FilterResponseEvent && !$e instanceof ResponseEvent) {
+            return;
+        }
+
         if (HttpKernelInterface::MASTER_REQUEST !== $e->getRequestType()) {
             return;
         }

--- a/EventListener/ReferrerPolicyListener.php
+++ b/EventListener/ReferrerPolicyListener.php
@@ -19,6 +19,7 @@ use Symfony\Component\HttpKernel\HttpKernelInterface;
  * Referrer Policy Listener.
  *
  * @author Andrej Hudec <pulzarraider@gmail.com>
+ * @final
  */
 class ReferrerPolicyListener
 {

--- a/EventListener/ReferrerPolicyListener.php
+++ b/EventListener/ReferrerPolicyListener.php
@@ -36,7 +36,7 @@ class ReferrerPolicyListener
     {
         // Compatibility with Symfony < 5 and Symfony >=5
         if (!$e instanceof FilterResponseEvent && !$e instanceof ResponseEvent) {
-            return;
+            throw new \InvalidArgumentException(\sprintf('Expected instance of type %s, %s given', \class_exists(ResponseEvent::class) ? ResponseEvent::class : FilterResponseEvent::class, \is_object($e) ? \get_class($e) : \gettype($e)));
         }
 
         if (HttpKernelInterface::MASTER_REQUEST !== $e->getRequestType()) {

--- a/EventListener/SignedCookieListener.php
+++ b/EventListener/SignedCookieListener.php
@@ -14,7 +14,9 @@ namespace Nelmio\SecurityBundle\EventListener;
 use Nelmio\SecurityBundle\Signer;
 use Symfony\Component\HttpFoundation\Cookie;
 use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 
 class SignedCookieListener
@@ -32,8 +34,16 @@ class SignedCookieListener
         }
     }
 
-    public function onKernelRequest(GetResponseEvent $e)
+    /**
+     * @param GetResponseEvent|RequestEvent $e
+     */
+    public function onKernelRequest($e)
     {
+        // Compatibility with Symfony < 5 and Symfony >=5
+        if (!$e instanceof GetResponseEvent && !$e instanceof RequestEvent) {
+            return;
+        }
+
         if (HttpKernelInterface::MASTER_REQUEST !== $e->getRequestType()) {
             return;
         }
@@ -53,8 +63,16 @@ class SignedCookieListener
         }
     }
 
-    public function onKernelResponse(FilterResponseEvent $e)
+    /**
+     * @param FilterResponseEvent|ResponseEvent $e
+     */
+    public function onKernelResponse($e)
     {
+        // Compatibility with Symfony < 5 and Symfony >=5
+        if (!$e instanceof FilterResponseEvent && !$e instanceof ResponseEvent) {
+            return;
+        }
+
         if (HttpKernelInterface::MASTER_REQUEST !== $e->getRequestType()) {
             return;
         }

--- a/EventListener/SignedCookieListener.php
+++ b/EventListener/SignedCookieListener.php
@@ -19,6 +19,9 @@ use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 
+/**
+ * @final
+ */
 class SignedCookieListener
 {
     private $signer;

--- a/EventListener/SignedCookieListener.php
+++ b/EventListener/SignedCookieListener.php
@@ -41,7 +41,7 @@ class SignedCookieListener
     {
         // Compatibility with Symfony < 5 and Symfony >=5
         if (!$e instanceof GetResponseEvent && !$e instanceof RequestEvent) {
-            return;
+            throw new \InvalidArgumentException(\sprintf('Expected instance of type %s, %s given', \class_exists(RequestEvent::class) ? RequestEvent::class : GetResponseEvent::class, \is_object($e) ? \get_class($e) : \gettype($e)));
         }
 
         if (HttpKernelInterface::MASTER_REQUEST !== $e->getRequestType()) {
@@ -70,7 +70,7 @@ class SignedCookieListener
     {
         // Compatibility with Symfony < 5 and Symfony >=5
         if (!$e instanceof FilterResponseEvent && !$e instanceof ResponseEvent) {
-            return;
+            throw new \InvalidArgumentException(\sprintf('Expected instance of type %s, %s given', \class_exists(ResponseEvent::class) ? ResponseEvent::class : FilterResponseEvent::class, \is_object($e) ? \get_class($e) : \gettype($e)));
         }
 
         if (HttpKernelInterface::MASTER_REQUEST !== $e->getRequestType()) {

--- a/EventListener/XssProtectionListener.php
+++ b/EventListener/XssProtectionListener.php
@@ -12,6 +12,7 @@
 namespace Nelmio\SecurityBundle\EventListener;
 
 use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\KernelEvents;
@@ -29,8 +30,16 @@ class XssProtectionListener implements EventSubscriberInterface
         $this->reportUri = $reportUri;
     }
 
-    public function onKernelResponse(FilterResponseEvent $e)
+    /**
+     * @param FilterResponseEvent|ResponseEvent $e
+     */
+    public function onKernelResponse($e)
     {
+        // Compatibility with Symfony < 5 and Symfony >=5
+        if (!$e instanceof FilterResponseEvent && !$e instanceof ResponseEvent) {
+            return;
+        }
+
         if (HttpKernelInterface::MASTER_REQUEST !== $e->getRequestType()) {
             return;
         }

--- a/EventListener/XssProtectionListener.php
+++ b/EventListener/XssProtectionListener.php
@@ -37,7 +37,7 @@ class XssProtectionListener implements EventSubscriberInterface
     {
         // Compatibility with Symfony < 5 and Symfony >=5
         if (!$e instanceof FilterResponseEvent && !$e instanceof ResponseEvent) {
-            return;
+            throw new \InvalidArgumentException(\sprintf('Expected instance of type %s, %s given', \class_exists(ResponseEvent::class) ? ResponseEvent::class : FilterResponseEvent::class, \is_object($e) ? \get_class($e) : \gettype($e)));
         }
 
         if (HttpKernelInterface::MASTER_REQUEST !== $e->getRequestType()) {

--- a/EventListener/XssProtectionListener.php
+++ b/EventListener/XssProtectionListener.php
@@ -17,6 +17,9 @@ use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\KernelEvents;
 
+/**
+ * @final
+ */
 class XssProtectionListener implements EventSubscriberInterface
 {
     private $enabled;

--- a/Session/CookieSessionHandler.php
+++ b/Session/CookieSessionHandler.php
@@ -13,6 +13,8 @@ namespace Nelmio\SecurityBundle\Session;
 
 use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpFoundation\Cookie;
 use Psr\Log\LoggerInterface;
@@ -58,10 +60,15 @@ class CookieSessionHandler implements \SessionHandlerInterface
     }
 
     /**
-     * @param FilterResponseEvent $e
+     * @param FilterResponseEvent|ResponseEvent $e
      */
-    public function onKernelResponse(FilterResponseEvent $e)
+    public function onKernelResponse($e)
     {
+        // Compatibility with Symfony < 5 and Symfony >=5
+        if (!$e instanceof FilterResponseEvent && !$e instanceof ResponseEvent) {
+            return;
+        }
+
         if (HttpKernelInterface::MASTER_REQUEST !== $e->getRequestType()) {
             return;
         }
@@ -91,10 +98,15 @@ class CookieSessionHandler implements \SessionHandlerInterface
     }
 
     /**
-     * @param GetResponseEvent $e
+     * @param GetResponseEvent|RequestEvent $e
      */
-    public function onKernelRequest(GetResponseEvent $e)
+    public function onKernelRequest($e)
     {
+        // Compatibility with Symfony < 5 and Symfony >=5
+        if (!$e instanceof GetResponseEvent && !$e instanceof RequestEvent) {
+            return;
+        }
+
         if (HttpKernelInterface::MASTER_REQUEST !== $e->getRequestType()) {
             return;
         }

--- a/Session/CookieSessionHandler.php
+++ b/Session/CookieSessionHandler.php
@@ -66,7 +66,7 @@ class CookieSessionHandler implements \SessionHandlerInterface
     {
         // Compatibility with Symfony < 5 and Symfony >=5
         if (!$e instanceof FilterResponseEvent && !$e instanceof ResponseEvent) {
-            return;
+            throw new \InvalidArgumentException(\sprintf('Expected instance of type %s, %s given', \class_exists(ResponseEvent::class) ? ResponseEvent::class : FilterResponseEvent::class, \is_object($e) ? \get_class($e) : \gettype($e)));
         }
 
         if (HttpKernelInterface::MASTER_REQUEST !== $e->getRequestType()) {
@@ -104,7 +104,7 @@ class CookieSessionHandler implements \SessionHandlerInterface
     {
         // Compatibility with Symfony < 5 and Symfony >=5
         if (!$e instanceof GetResponseEvent && !$e instanceof RequestEvent) {
-            return;
+            throw new \InvalidArgumentException(\sprintf('Expected instance of type %s, %s given', \class_exists(RequestEvent::class) ? RequestEvent::class : GetResponseEvent::class, \is_object($e) ? \get_class($e) : \gettype($e)));
         }
 
         if (HttpKernelInterface::MASTER_REQUEST !== $e->getRequestType()) {

--- a/Session/CookieSessionHandler.php
+++ b/Session/CookieSessionHandler.php
@@ -19,6 +19,9 @@ use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpFoundation\Cookie;
 use Psr\Log\LoggerInterface;
 
+/**
+ * @final
+ */
 class CookieSessionHandler implements \SessionHandlerInterface
 {
     protected $request;

--- a/Tests/ContentSecurityPolicy/ShaComputerTest.php
+++ b/Tests/ContentSecurityPolicy/ShaComputerTest.php
@@ -67,11 +67,12 @@ class ShaComputerTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
-     * @expectedException \InvalidArgumentException
      * @dataProvider provideInvalidScriptCode
      */
     public function testComputeScriptShouldFail($code)
     {
+        $this->expectException(\InvalidArgumentException::class);
+
         $shaComputer = new ShaComputer('sha256');
         $shaComputer->computeForScript($code);
     }

--- a/Tests/ContentSecurityPolicy/ShaComputerTest.php
+++ b/Tests/ContentSecurityPolicy/ShaComputerTest.php
@@ -71,7 +71,7 @@ class ShaComputerTest extends \PHPUnit\Framework\TestCase
      */
     public function testComputeScriptShouldFail($code)
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException('InvalidArgumentException');
 
         $shaComputer = new ShaComputer('sha256');
         $shaComputer->computeForScript($code);

--- a/Tests/ContentSecurityPolicy/Violation/ReportTest.php
+++ b/Tests/ContentSecurityPolicy/Violation/ReportTest.php
@@ -2,16 +2,13 @@
 
 namespace Nelmio\SecurityBundle\ContentSecurityPolicy\Violation;
 
-use Nelmio\SecurityBundle\ContentSecurityPolicy\Violation\Exception\InvalidPayloadException;
-use Nelmio\SecurityBundle\ContentSecurityPolicy\Violation\Exception\MissingCspReportException;
-use Nelmio\SecurityBundle\ContentSecurityPolicy\Violation\Exception\NoDataException;
 use Symfony\Component\HttpFoundation\Request;
 
 class ReportTest extends \PHPUnit\Framework\TestCase
 {
     public function testFromRequestWithoutData()
     {
-        $this->expectException(NoDataException::class);
+        $this->expectException('Nelmio\SecurityBundle\ContentSecurityPolicy\Violation\Exception\NoDataException');
         $this->expectExceptionMessage('Content-Security-Policy Endpoint called without data');
 
         Report::fromRequest(new Request());
@@ -19,7 +16,7 @@ class ReportTest extends \PHPUnit\Framework\TestCase
 
     public function testFromRequestWithoutReportKey()
     {
-        $this->expectException(MissingCspReportException::class);
+        $this->expectException('Nelmio\SecurityBundle\ContentSecurityPolicy\Violation\Exception\MissingCspReportException');
         $this->expectExceptionMessage('Content-Security-Policy Endpoint called without "csp-report" data');
 
         Report::fromRequest(new Request(array(), array(), array(), array(), array(), array(), '{}'));
@@ -27,7 +24,7 @@ class ReportTest extends \PHPUnit\Framework\TestCase
 
     public function testFromRequestWithInvalidJSON()
     {
-        $this->expectException(InvalidPayloadException::class);
+        $this->expectException('Nelmio\SecurityBundle\ContentSecurityPolicy\Violation\Exception\InvalidPayloadException');
         $this->expectExceptionMessage('Content-Security-Policy Endpoint called with invalid JSON data');
 
         Report::fromRequest(new Request(array(), array(), array(), array(), array(), array(), 'yolo'));

--- a/Tests/ContentSecurityPolicy/Violation/ReportTest.php
+++ b/Tests/ContentSecurityPolicy/Violation/ReportTest.php
@@ -2,34 +2,34 @@
 
 namespace Nelmio\SecurityBundle\ContentSecurityPolicy\Violation;
 
+use Nelmio\SecurityBundle\ContentSecurityPolicy\Violation\Exception\InvalidPayloadException;
+use Nelmio\SecurityBundle\ContentSecurityPolicy\Violation\Exception\MissingCspReportException;
+use Nelmio\SecurityBundle\ContentSecurityPolicy\Violation\Exception\NoDataException;
 use Symfony\Component\HttpFoundation\Request;
 
 class ReportTest extends \PHPUnit\Framework\TestCase
 {
-    /**
-     * @expectedException Nelmio\SecurityBundle\ContentSecurityPolicy\Violation\Exception\NoDataException
-     * @expectedExceptionMessage Content-Security-Policy Endpoint called without data
-     */
     public function testFromRequestWithoutData()
     {
+        $this->expectException(NoDataException::class);
+        $this->expectExceptionMessage('Content-Security-Policy Endpoint called without data');
+
         Report::fromRequest(new Request());
     }
 
-    /**
-     * @expectedException Nelmio\SecurityBundle\ContentSecurityPolicy\Violation\Exception\MissingCspReportException
-     * @expectedExceptionMessage Content-Security-Policy Endpoint called without "csp-report" data
-     */
     public function testFromRequestWithoutReportKey()
     {
+        $this->expectException(MissingCspReportException::class);
+        $this->expectExceptionMessage('Content-Security-Policy Endpoint called without "csp-report" data');
+
         Report::fromRequest(new Request(array(), array(), array(), array(), array(), array(), '{}'));
     }
 
-    /**
-     * @expectedException Nelmio\SecurityBundle\ContentSecurityPolicy\Violation\Exception\InvalidPayloadException
-     * @expectedExceptionMessage Content-Security-Policy Endpoint called with invalid JSON data
-     */
     public function testFromRequestWithInvalidJSON()
     {
+        $this->expectException(InvalidPayloadException::class);
+        $this->expectExceptionMessage('Content-Security-Policy Endpoint called with invalid JSON data');
+
         Report::fromRequest(new Request(array(), array(), array(), array(), array(), array(), 'yolo'));
     }
 

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -120,7 +120,7 @@ class ConfigurationTest extends \PHPUnit\Framework\TestCase
 
     public function testReferrerPolicyInvalid()
     {
-        $this->expectException(\Symfony\Component\Config\Definition\Exception\InvalidConfigurationException::class);
+        $this->expectException('Symfony\Component\Config\Definition\Exception\InvalidConfigurationException');
 
         $this->processYamlConfiguration(
             "referrer_policy:\n".

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -118,11 +118,10 @@ class ConfigurationTest extends \PHPUnit\Framework\TestCase
         );
     }
 
-    /**
-     * @expectedException Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
-     */
     public function testReferrerPolicyInvalid()
     {
+        $this->expectException(\Symfony\Component\Config\Definition\Exception\InvalidConfigurationException::class);
+
         $this->processYamlConfiguration(
             "referrer_policy:\n".
             "  enabled: true\n".

--- a/Tests/Listener/ClickjackingListenerTest.php
+++ b/Tests/Listener/ClickjackingListenerTest.php
@@ -14,6 +14,7 @@ namespace Nelmio\SecurityBundle\Tests\Listener;
 use Nelmio\SecurityBundle\EventListener\ClickjackingListener;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
 
@@ -70,7 +71,13 @@ class ClickjackingListenerTest extends \PHPUnit\Framework\TestCase
         $response = new Response();
         $response->headers->add(array('content-type' => $contentType));
 
-        $event = new FilterResponseEvent($this->kernel, $request, $masterReq ? HttpKernelInterface::MASTER_REQUEST : HttpKernelInterface::SUB_REQUEST, $response);
+        if (class_exists(ResponseEvent::class)) {
+            $class = ResponseEvent::class;
+        } else {
+            $class = FilterResponseEvent::class;
+        }
+
+        $event = new $class($this->kernel, $request, $masterReq ? HttpKernelInterface::MASTER_REQUEST : HttpKernelInterface::SUB_REQUEST, $response);
         $listener->onKernelResponse($event);
 
         return $response;

--- a/Tests/Listener/ClickjackingListenerTest.php
+++ b/Tests/Listener/ClickjackingListenerTest.php
@@ -14,9 +14,7 @@ namespace Nelmio\SecurityBundle\Tests\Listener;
 use Nelmio\SecurityBundle\EventListener\ClickjackingListener;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
-use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
 
 class ClickjackingListenerTest extends \PHPUnit\Framework\TestCase
 {
@@ -71,10 +69,10 @@ class ClickjackingListenerTest extends \PHPUnit\Framework\TestCase
         $response = new Response();
         $response->headers->add(array('content-type' => $contentType));
 
-        if (class_exists(ResponseEvent::class)) {
-            $class = ResponseEvent::class;
+        if (class_exists('Symfony\Component\HttpKernel\Event\ResponseEvent')) {
+            $class = 'Symfony\Component\HttpKernel\Event\ResponseEvent';
         } else {
-            $class = FilterResponseEvent::class;
+            $class = 'Symfony\Component\HttpKernel\Event\FilterResponseEvent';
         }
 
         $event = new $class($this->kernel, $request, $masterReq ? HttpKernelInterface::MASTER_REQUEST : HttpKernelInterface::SUB_REQUEST, $response);

--- a/Tests/Listener/ClickjackingListenerTest.php
+++ b/Tests/Listener/ClickjackingListenerTest.php
@@ -63,6 +63,22 @@ class ClickjackingListenerTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(null, $response->headers->get('X-Frame-Options'));
     }
 
+    public function testWrongEventClass()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        if (class_exists('Symfony\Component\HttpKernel\Event\ResponseEvent')) {
+            $this->expectExceptionMessage('Expected instance of type Symfony\Component\HttpKernel\Event\ResponseEvent, Symfony\Component\HttpFoundation\Response given');
+        } else {
+            $this->expectExceptionMessage('Expected instance of type Symfony\Component\HttpKernel\Event\FilterResponseEvent, Symfony\Component\HttpFoundation\Response given');
+        }
+
+        $response = new Response();
+        $this->listener->onKernelResponse($response);
+
+        return $response;
+    }
+
     protected function callListener($listener, $path, $masterReq, $contentType = 'text/html')
     {
         $request = Request::create($path);

--- a/Tests/Listener/ContentSecurityPolicyListenerTest.php
+++ b/Tests/Listener/ContentSecurityPolicyListenerTest.php
@@ -249,23 +249,29 @@ class ContentSecurityPolicyListenerTest extends \PHPUnit\Framework\TestCase
 
         $header = $response->headers->get('Content-Security-Policy');
 
-        $this->assertStringContainsString("default-src example.org 'self'", $header, 'Header should contain default-src');
-        $this->assertStringContainsString("script-src script.example.org 'self'", $header, 'Header should contain script-src');
-        $this->assertStringContainsString("object-src object.example.org 'self'", $header, 'Header should contain object-src');
-        $this->assertStringContainsString("style-src style.example.org 'self'", $header, 'Header should contain style-src');
-        $this->assertStringContainsString("img-src img.example.org 'self'", $header, 'Header should contain img-src');
-        $this->assertStringContainsString("media-src media.example.org 'self'", $header, 'Header should contain media-src');
-        $this->assertStringContainsString("frame-src frame.example.org 'self'", $header, 'Header should contain frame-src');
-        $this->assertStringContainsString("font-src font.example.org 'self'", $header, 'Header should contain font-src');
-        $this->assertStringContainsString("connect-src connect.example.org 'self'", $header, 'Header should contain connect-src');
-        $this->assertStringContainsString('report-uri http://example.org/CSPReport', $header, 'Header should contain report-uri');
-        $this->assertStringContainsString("base-uri base-uri.example.org 'self'", $header, 'Header should contain base-uri');
-        $this->assertStringContainsString("child-src child-src.example.org 'self'", $header, 'Header should contain child-src');
-        $this->assertStringContainsString("form-action form-action.example.org 'self'", $header, 'Header should contain form-action');
-        $this->assertStringContainsString("frame-ancestors frame-ancestors.example.org 'self'", $header, 'Header should contain frame-ancestors');
-        $this->assertStringContainsString('plugin-types application/shockwave-flash', $header, 'Header should contain plugin-types');
-        $this->assertStringContainsString('block-all-mixed-content', $header, 'Header should contain block-all-mixed-content');
-        $this->assertStringContainsString('upgrade-insecure-requests', $header, 'Header should contain upgrade-insecure-requests');
+        if (method_exists($this, 'assertStringContainsString')) {
+            $assertMethod = 'assertStringContainsString';
+        } else {
+            $assertMethod = 'assertContains';
+        }
+
+        $this->$assertMethod("default-src example.org 'self'", $header, 'Header should contain default-src');
+        $this->$assertMethod("script-src script.example.org 'self'", $header, 'Header should contain script-src');
+        $this->$assertMethod("object-src object.example.org 'self'", $header, 'Header should contain object-src');
+        $this->$assertMethod("style-src style.example.org 'self'", $header, 'Header should contain style-src');
+        $this->$assertMethod("img-src img.example.org 'self'", $header, 'Header should contain img-src');
+        $this->$assertMethod("media-src media.example.org 'self'", $header, 'Header should contain media-src');
+        $this->$assertMethod("frame-src frame.example.org 'self'", $header, 'Header should contain frame-src');
+        $this->$assertMethod("font-src font.example.org 'self'", $header, 'Header should contain font-src');
+        $this->$assertMethod("connect-src connect.example.org 'self'", $header, 'Header should contain connect-src');
+        $this->$assertMethod('report-uri http://example.org/CSPReport', $header, 'Header should contain report-uri');
+        $this->$assertMethod("base-uri base-uri.example.org 'self'", $header, 'Header should contain base-uri');
+        $this->$assertMethod("child-src child-src.example.org 'self'", $header, 'Header should contain child-src');
+        $this->$assertMethod("form-action form-action.example.org 'self'", $header, 'Header should contain form-action');
+        $this->$assertMethod("frame-ancestors frame-ancestors.example.org 'self'", $header, 'Header should contain frame-ancestors');
+        $this->$assertMethod('plugin-types application/shockwave-flash', $header, 'Header should contain plugin-types');
+        $this->$assertMethod('block-all-mixed-content', $header, 'Header should contain block-all-mixed-content');
+        $this->$assertMethod('upgrade-insecure-requests', $header, 'Header should contain upgrade-insecure-requests');
     }
 
     public function testDelimiter()

--- a/Tests/Listener/ContentSecurityPolicyListenerTest.php
+++ b/Tests/Listener/ContentSecurityPolicyListenerTest.php
@@ -249,23 +249,23 @@ class ContentSecurityPolicyListenerTest extends \PHPUnit\Framework\TestCase
 
         $header = $response->headers->get('Content-Security-Policy');
 
-        $this->assertContains("default-src example.org 'self'", $header, 'Header should contain default-src');
-        $this->assertContains("script-src script.example.org 'self'", $header, 'Header should contain script-src');
-        $this->assertContains("object-src object.example.org 'self'", $header, 'Header should contain object-src');
-        $this->assertContains("style-src style.example.org 'self'", $header, 'Header should contain style-src');
-        $this->assertContains("img-src img.example.org 'self'", $header, 'Header should contain img-src');
-        $this->assertContains("media-src media.example.org 'self'", $header, 'Header should contain media-src');
-        $this->assertContains("frame-src frame.example.org 'self'", $header, 'Header should contain frame-src');
-        $this->assertContains("font-src font.example.org 'self'", $header, 'Header should contain font-src');
-        $this->assertContains("connect-src connect.example.org 'self'", $header, 'Header should contain connect-src');
-        $this->assertContains('report-uri http://example.org/CSPReport', $header, 'Header should contain report-uri');
-        $this->assertContains("base-uri base-uri.example.org 'self'", $header, 'Header should contain base-uri');
-        $this->assertContains("child-src child-src.example.org 'self'", $header, 'Header should contain child-src');
-        $this->assertContains("form-action form-action.example.org 'self'", $header, 'Header should contain form-action');
-        $this->assertContains("frame-ancestors frame-ancestors.example.org 'self'", $header, 'Header should contain frame-ancestors');
-        $this->assertContains('plugin-types application/shockwave-flash', $header, 'Header should contain plugin-types');
-        $this->assertContains('block-all-mixed-content', $header, 'Header should contain block-all-mixed-content');
-        $this->assertContains('upgrade-insecure-requests', $header, 'Header should contain upgrade-insecure-requests');
+        $this->assertStringContainsString("default-src example.org 'self'", $header, 'Header should contain default-src');
+        $this->assertStringContainsString("script-src script.example.org 'self'", $header, 'Header should contain script-src');
+        $this->assertStringContainsString("object-src object.example.org 'self'", $header, 'Header should contain object-src');
+        $this->assertStringContainsString("style-src style.example.org 'self'", $header, 'Header should contain style-src');
+        $this->assertStringContainsString("img-src img.example.org 'self'", $header, 'Header should contain img-src');
+        $this->assertStringContainsString("media-src media.example.org 'self'", $header, 'Header should contain media-src');
+        $this->assertStringContainsString("frame-src frame.example.org 'self'", $header, 'Header should contain frame-src');
+        $this->assertStringContainsString("font-src font.example.org 'self'", $header, 'Header should contain font-src');
+        $this->assertStringContainsString("connect-src connect.example.org 'self'", $header, 'Header should contain connect-src');
+        $this->assertStringContainsString('report-uri http://example.org/CSPReport', $header, 'Header should contain report-uri');
+        $this->assertStringContainsString("base-uri base-uri.example.org 'self'", $header, 'Header should contain base-uri');
+        $this->assertStringContainsString("child-src child-src.example.org 'self'", $header, 'Header should contain child-src');
+        $this->assertStringContainsString("form-action form-action.example.org 'self'", $header, 'Header should contain form-action');
+        $this->assertStringContainsString("frame-ancestors frame-ancestors.example.org 'self'", $header, 'Header should contain frame-ancestors');
+        $this->assertStringContainsString('plugin-types application/shockwave-flash', $header, 'Header should contain plugin-types');
+        $this->assertStringContainsString('block-all-mixed-content', $header, 'Header should contain block-all-mixed-content');
+        $this->assertStringContainsString('upgrade-insecure-requests', $header, 'Header should contain upgrade-insecure-requests');
     }
 
     public function testDelimiter()

--- a/Tests/Listener/ContentSecurityPolicyListenerTest.php
+++ b/Tests/Listener/ContentSecurityPolicyListenerTest.php
@@ -255,23 +255,23 @@ class ContentSecurityPolicyListenerTest extends \PHPUnit\Framework\TestCase
             $assertMethod = 'assertContains';
         }
 
-        $this->$assertMethod("default-src example.org 'self'", $header, 'Header should contain default-src');
-        $this->$assertMethod("script-src script.example.org 'self'", $header, 'Header should contain script-src');
-        $this->$assertMethod("object-src object.example.org 'self'", $header, 'Header should contain object-src');
-        $this->$assertMethod("style-src style.example.org 'self'", $header, 'Header should contain style-src');
-        $this->$assertMethod("img-src img.example.org 'self'", $header, 'Header should contain img-src');
-        $this->$assertMethod("media-src media.example.org 'self'", $header, 'Header should contain media-src');
-        $this->$assertMethod("frame-src frame.example.org 'self'", $header, 'Header should contain frame-src');
-        $this->$assertMethod("font-src font.example.org 'self'", $header, 'Header should contain font-src');
-        $this->$assertMethod("connect-src connect.example.org 'self'", $header, 'Header should contain connect-src');
-        $this->$assertMethod('report-uri http://example.org/CSPReport', $header, 'Header should contain report-uri');
-        $this->$assertMethod("base-uri base-uri.example.org 'self'", $header, 'Header should contain base-uri');
-        $this->$assertMethod("child-src child-src.example.org 'self'", $header, 'Header should contain child-src');
-        $this->$assertMethod("form-action form-action.example.org 'self'", $header, 'Header should contain form-action');
-        $this->$assertMethod("frame-ancestors frame-ancestors.example.org 'self'", $header, 'Header should contain frame-ancestors');
-        $this->$assertMethod('plugin-types application/shockwave-flash', $header, 'Header should contain plugin-types');
-        $this->$assertMethod('block-all-mixed-content', $header, 'Header should contain block-all-mixed-content');
-        $this->$assertMethod('upgrade-insecure-requests', $header, 'Header should contain upgrade-insecure-requests');
+        $this->{$assertMethod}("default-src example.org 'self'", $header, 'Header should contain default-src');
+        $this->{$assertMethod}("script-src script.example.org 'self'", $header, 'Header should contain script-src');
+        $this->{$assertMethod}("object-src object.example.org 'self'", $header, 'Header should contain object-src');
+        $this->{$assertMethod}("style-src style.example.org 'self'", $header, 'Header should contain style-src');
+        $this->{$assertMethod}("img-src img.example.org 'self'", $header, 'Header should contain img-src');
+        $this->{$assertMethod}("media-src media.example.org 'self'", $header, 'Header should contain media-src');
+        $this->{$assertMethod}("frame-src frame.example.org 'self'", $header, 'Header should contain frame-src');
+        $this->{$assertMethod}("font-src font.example.org 'self'", $header, 'Header should contain font-src');
+        $this->{$assertMethod}("connect-src connect.example.org 'self'", $header, 'Header should contain connect-src');
+        $this->{$assertMethod}('report-uri http://example.org/CSPReport', $header, 'Header should contain report-uri');
+        $this->{$assertMethod}("base-uri base-uri.example.org 'self'", $header, 'Header should contain base-uri');
+        $this->{$assertMethod}("child-src child-src.example.org 'self'", $header, 'Header should contain child-src');
+        $this->{$assertMethod}("form-action form-action.example.org 'self'", $header, 'Header should contain form-action');
+        $this->{$assertMethod}("frame-ancestors frame-ancestors.example.org 'self'", $header, 'Header should contain frame-ancestors');
+        $this->{$assertMethod}('plugin-types application/shockwave-flash', $header, 'Header should contain plugin-types');
+        $this->{$assertMethod}('block-all-mixed-content', $header, 'Header should contain block-all-mixed-content');
+        $this->{$assertMethod}('upgrade-insecure-requests', $header, 'Header should contain upgrade-insecure-requests');
     }
 
     public function testDelimiter()

--- a/Tests/Listener/ContentSecurityPolicyListenerTest.php
+++ b/Tests/Listener/ContentSecurityPolicyListenerTest.php
@@ -2,16 +2,10 @@
 
 namespace Nelmio\SecurityBundle\Tests\Listener;
 
-use Nelmio\SecurityBundle\ContentSecurityPolicy\NonceGenerator;
 use Nelmio\SecurityBundle\ContentSecurityPolicy\PolicyManager;
-use Nelmio\SecurityBundle\ContentSecurityPolicy\ShaComputer;
 use Nelmio\SecurityBundle\EventListener\ContentSecurityPolicyListener;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
-use Symfony\Component\HttpKernel\Event\GetResponseEvent;
-use Symfony\Component\HttpKernel\Event\RequestEvent;
-use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Nelmio\SecurityBundle\ContentSecurityPolicy\DirectiveSet;
 
@@ -416,10 +410,10 @@ class ContentSecurityPolicyListenerTest extends \PHPUnit\Framework\TestCase
     {
         $request = Request::create($path);
 
-        if (class_exists(RequestEvent::class)) {
-            $class = RequestEvent::class;
+        if (class_exists('Symfony\Component\HttpKernel\Event\RequestEvent')) {
+            $class = 'Symfony\Component\HttpKernel\Event\RequestEvent';
         } else {
-            $class = GetResponseEvent::class;
+            $class = 'Symfony\Component\HttpKernel\Event\GetResponseEvent';
         }
 
         $event = new $class(
@@ -457,10 +451,10 @@ class ContentSecurityPolicyListenerTest extends \PHPUnit\Framework\TestCase
         $response = new Response();
         $response->headers->add(array('content-type' => $contentType));
 
-        if (class_exists(ResponseEvent::class)) {
-            $class = ResponseEvent::class;
+        if (class_exists('Symfony\Component\HttpKernel\Event\ResponseEvent')) {
+            $class = 'Symfony\Component\HttpKernel\Event\ResponseEvent';
         } else {
-            $class = FilterResponseEvent::class;
+            $class = 'Symfony\Component\HttpKernel\Event\FilterResponseEvent';
         }
 
         $event = new $class(

--- a/Tests/Listener/ContentSecurityPolicyListenerTest.php
+++ b/Tests/Listener/ContentSecurityPolicyListenerTest.php
@@ -10,6 +10,8 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Nelmio\SecurityBundle\ContentSecurityPolicy\DirectiveSet;
 
@@ -407,7 +409,14 @@ class ContentSecurityPolicyListenerTest extends \PHPUnit\Framework\TestCase
     protected function callListener(ContentSecurityPolicyListener $listener, $path, $masterReq, $contentType = 'text/html', array $digestData = array(), $getNonce = 0)
     {
         $request = Request::create($path);
-        $event = new GetResponseEvent(
+
+        if (class_exists(RequestEvent::class)) {
+            $class = RequestEvent::class;
+        } else {
+            $class = GetResponseEvent::class;
+        }
+
+        $event = new $class(
             $this->kernel,
             $request,
             $masterReq ? HttpKernelInterface::MASTER_REQUEST : HttpKernelInterface::SUB_REQUEST
@@ -442,7 +451,13 @@ class ContentSecurityPolicyListenerTest extends \PHPUnit\Framework\TestCase
         $response = new Response();
         $response->headers->add(array('content-type' => $contentType));
 
-        $event = new FilterResponseEvent(
+        if (class_exists(ResponseEvent::class)) {
+            $class = ResponseEvent::class;
+        } else {
+            $class = FilterResponseEvent::class;
+        }
+
+        $event = new $class(
             $this->kernel,
             $request,
             $masterReq ? HttpKernelInterface::MASTER_REQUEST : HttpKernelInterface::SUB_REQUEST,

--- a/Tests/Listener/ContentTypeListenerTest.php
+++ b/Tests/Listener/ContentTypeListenerTest.php
@@ -5,8 +5,6 @@ namespace Nelmio\SecurityBundle\Tests\Listener;
 use Nelmio\SecurityBundle\EventListener\ContentTypeListener;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
-use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 
 class ContentTypeListenerTest extends \PHPUnit\Framework\TestCase
@@ -44,10 +42,10 @@ class ContentTypeListenerTest extends \PHPUnit\Framework\TestCase
         $request = Request::create($path);
         $response = new Response();
 
-        if (class_exists(ResponseEvent::class)) {
-            $class = ResponseEvent::class;
+        if (class_exists('Symfony\Component\HttpKernel\Event\ResponseEvent')) {
+            $class = 'Symfony\Component\HttpKernel\Event\ResponseEvent';
         } else {
-            $class = FilterResponseEvent::class;
+            $class = 'Symfony\Component\HttpKernel\Event\FilterResponseEvent';
         }
 
         $event = new $class($this->kernel, $request, $masterReq ? HttpKernelInterface::MASTER_REQUEST : HttpKernelInterface::SUB_REQUEST, $response);

--- a/Tests/Listener/ContentTypeListenerTest.php
+++ b/Tests/Listener/ContentTypeListenerTest.php
@@ -6,6 +6,7 @@ use Nelmio\SecurityBundle\EventListener\ContentTypeListener;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 
 class ContentTypeListenerTest extends \PHPUnit\Framework\TestCase
@@ -43,7 +44,13 @@ class ContentTypeListenerTest extends \PHPUnit\Framework\TestCase
         $request = Request::create($path);
         $response = new Response();
 
-        $event = new FilterResponseEvent($this->kernel, $request, $masterReq ? HttpKernelInterface::MASTER_REQUEST : HttpKernelInterface::SUB_REQUEST, $response);
+        if (class_exists(ResponseEvent::class)) {
+            $class = ResponseEvent::class;
+        } else {
+            $class = FilterResponseEvent::class;
+        }
+
+        $event = new $class($this->kernel, $request, $masterReq ? HttpKernelInterface::MASTER_REQUEST : HttpKernelInterface::SUB_REQUEST, $response);
         $listener->onKernelResponse($event);
 
         return $response;

--- a/Tests/Listener/EncryptedCookieListenerTest.php
+++ b/Tests/Listener/EncryptedCookieListenerTest.php
@@ -16,11 +16,7 @@ use Nelmio\SecurityBundle\EventListener\EncryptedCookieListener;
 use Symfony\Component\HttpFoundation\Cookie;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpKernel\Event\RequestEvent;
-use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
-use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
-use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 
 class EncryptedCookieListenerTest extends \PHPUnit\Framework\TestCase
 {
@@ -53,10 +49,10 @@ class EncryptedCookieListenerTest extends \PHPUnit\Framework\TestCase
         $listener = new EncryptedCookieListener($this->encrypter, $encryptedCookieNames);
         $request = Request::create('/', 'GET', array(), $inputCookies);
 
-        if (class_exists(RequestEvent::class)) {
-            $class = RequestEvent::class;
+        if (class_exists('Symfony\Component\HttpKernel\Event\RequestEvent')) {
+            $class = 'Symfony\Component\HttpKernel\Event\RequestEvent';
         } else {
-            $class = GetResponseEvent::class;
+            $class = 'Symfony\Component\HttpKernel\Event\GetResponseEvent';
         }
 
         $event = new $class($this->kernel, $request, HttpKernelInterface::MASTER_REQUEST);
@@ -90,10 +86,10 @@ class EncryptedCookieListenerTest extends \PHPUnit\Framework\TestCase
             $response->headers->setCookie(method_exists('Symfony\\Component\\HttpFoundation\\Cookie', 'create') ? Cookie::create($name, $cookie) : new Cookie($name, $cookie));
         }
 
-        if (class_exists(ResponseEvent::class)) {
-            $class = ResponseEvent::class;
+        if (class_exists('Symfony\Component\HttpKernel\Event\ResponseEvent')) {
+            $class = 'Symfony\Component\HttpKernel\Event\ResponseEvent';
         } else {
-            $class = FilterResponseEvent::class;
+            $class = 'Symfony\Component\HttpKernel\Event\FilterResponseEvent';
         }
 
         $event = new $class($this->kernel, $request, HttpKernelInterface::MASTER_REQUEST, $response);
@@ -134,10 +130,10 @@ class EncryptedCookieListenerTest extends \PHPUnit\Framework\TestCase
             $response->headers->setCookie(method_exists('Symfony\\Component\\HttpFoundation\\Cookie', 'create') ? Cookie::create($name, $cookie) : new Cookie($name, $cookie));
         }
 
-        if (class_exists(ResponseEvent::class)) {
-            $class = ResponseEvent::class;
+        if (class_exists('Symfony\Component\HttpKernel\Event\ResponseEvent')) {
+            $class = 'Symfony\Component\HttpKernel\Event\ResponseEvent';
         } else {
-            $class = FilterResponseEvent::class;
+            $class = 'Symfony\Component\HttpKernel\Event\FilterResponseEvent';
         }
 
         $event = new $class($this->kernel, $request, HttpKernelInterface::MASTER_REQUEST, $response);
@@ -152,10 +148,10 @@ class EncryptedCookieListenerTest extends \PHPUnit\Framework\TestCase
 
         $request = Request::create('/', 'GET', array(), $responseCookieValues);
 
-        if (class_exists(RequestEvent::class)) {
-            $class = RequestEvent::class;
+        if (class_exists('Symfony\Component\HttpKernel\Event\RequestEvent')) {
+            $class = 'Symfony\Component\HttpKernel\Event\RequestEvent';
         } else {
-            $class = GetResponseEvent::class;
+            $class = 'Symfony\Component\HttpKernel\Event\GetResponseEvent';
         }
 
         $event = new $class($this->kernel, $request, HttpKernelInterface::MASTER_REQUEST);

--- a/Tests/Listener/EncryptedCookieListenerTest.php
+++ b/Tests/Listener/EncryptedCookieListenerTest.php
@@ -16,6 +16,8 @@ use Nelmio\SecurityBundle\EventListener\EncryptedCookieListener;
 use Symfony\Component\HttpFoundation\Cookie;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
@@ -51,7 +53,13 @@ class EncryptedCookieListenerTest extends \PHPUnit\Framework\TestCase
         $listener = new EncryptedCookieListener($this->encrypter, $encryptedCookieNames);
         $request = Request::create('/', 'GET', array(), $inputCookies);
 
-        $event = new GetResponseEvent($this->kernel, $request, HttpKernelInterface::MASTER_REQUEST);
+        if (class_exists(RequestEvent::class)) {
+            $class = RequestEvent::class;
+        } else {
+            $class = GetResponseEvent::class;
+        }
+
+        $event = new $class($this->kernel, $request, HttpKernelInterface::MASTER_REQUEST);
         $listener->onKernelRequest($event);
 
         $this->assertSame($expectedCookies, $request->cookies->all());
@@ -82,7 +90,13 @@ class EncryptedCookieListenerTest extends \PHPUnit\Framework\TestCase
             $response->headers->setCookie(method_exists('Symfony\\Component\\HttpFoundation\\Cookie', 'create') ? Cookie::create($name, $cookie) : new Cookie($name, $cookie));
         }
 
-        $event = new FilterResponseEvent($this->kernel, $request, HttpKernelInterface::MASTER_REQUEST, $response);
+        if (class_exists(ResponseEvent::class)) {
+            $class = ResponseEvent::class;
+        } else {
+            $class = FilterResponseEvent::class;
+        }
+
+        $event = new $class($this->kernel, $request, HttpKernelInterface::MASTER_REQUEST, $response);
         $listener->onKernelResponse($event);
 
         $responseCookieValues = array();
@@ -120,7 +134,13 @@ class EncryptedCookieListenerTest extends \PHPUnit\Framework\TestCase
             $response->headers->setCookie(method_exists('Symfony\\Component\\HttpFoundation\\Cookie', 'create') ? Cookie::create($name, $cookie) : new Cookie($name, $cookie));
         }
 
-        $event = new FilterResponseEvent($this->kernel, $request, HttpKernelInterface::MASTER_REQUEST, $response);
+        if (class_exists(ResponseEvent::class)) {
+            $class = ResponseEvent::class;
+        } else {
+            $class = FilterResponseEvent::class;
+        }
+
+        $event = new $class($this->kernel, $request, HttpKernelInterface::MASTER_REQUEST, $response);
         $listener->onKernelResponse($event);
 
         $responseCookieValues = array();
@@ -132,7 +152,13 @@ class EncryptedCookieListenerTest extends \PHPUnit\Framework\TestCase
 
         $request = Request::create('/', 'GET', array(), $responseCookieValues);
 
-        $event = new GetResponseEvent($this->kernel, $request, HttpKernelInterface::MASTER_REQUEST);
+        if (class_exists(RequestEvent::class)) {
+            $class = RequestEvent::class;
+        } else {
+            $class = GetResponseEvent::class;
+        }
+
+        $event = new $class($this->kernel, $request, HttpKernelInterface::MASTER_REQUEST);
         $listener->onKernelRequest($event);
 
         $this->assertSame($inputCookies, $request->cookies->all());

--- a/Tests/Listener/ExternalRedirectListenerTest.php
+++ b/Tests/Listener/ExternalRedirectListenerTest.php
@@ -15,6 +15,7 @@ use Nelmio\SecurityBundle\EventListener\ExternalRedirectListener;
 use Nelmio\SecurityBundle\ExternalRedirect\WhitelistBasedTargetValidator;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
 
@@ -144,7 +145,13 @@ class ExternalRedirectListenerTest extends \PHPUnit\Framework\TestCase
 
         $response = new RedirectResponse('http://foo.com/');
 
-        $event = new FilterResponseEvent($this->kernel, $request, HttpKernelInterface::SUB_REQUEST, $response);
+        if (class_exists(ResponseEvent::class)) {
+            $class = ResponseEvent::class;
+        } else {
+            $class = FilterResponseEvent::class;
+        }
+
+        $event = new $class($this->kernel, $request, HttpKernelInterface::SUB_REQUEST, $response);
         $listener->onKernelResponse($event);
 
         $this->assertSame(true, $response->isRedirect());
@@ -157,7 +164,13 @@ class ExternalRedirectListenerTest extends \PHPUnit\Framework\TestCase
 
         $response = new RedirectResponse($target);
 
-        $event = new FilterResponseEvent($this->kernel, $request, HttpKernelInterface::MASTER_REQUEST, $response);
+        if (class_exists(ResponseEvent::class)) {
+            $class = ResponseEvent::class;
+        } else {
+            $class = FilterResponseEvent::class;
+        }
+
+        $event = new $class($this->kernel, $request, HttpKernelInterface::MASTER_REQUEST, $response);
         $listener->onKernelResponse($event);
 
         return $response;

--- a/Tests/Listener/ExternalRedirectListenerTest.php
+++ b/Tests/Listener/ExternalRedirectListenerTest.php
@@ -15,10 +15,7 @@ use Nelmio\SecurityBundle\EventListener\ExternalRedirectListener;
 use Nelmio\SecurityBundle\ExternalRedirect\WhitelistBasedTargetValidator;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RedirectResponse;
-use Symfony\Component\HttpKernel\Event\ResponseEvent;
-use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
-use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
 
 class ExternalRedirectListenerTest extends \PHPUnit\Framework\TestCase
 {
@@ -65,7 +62,7 @@ class ExternalRedirectListenerTest extends \PHPUnit\Framework\TestCase
      */
     public function testRedirectAbort()
     {
-        $this->expectException(HttpException::class);
+        $this->expectException('Symfony\Component\HttpKernel\Exception\HttpException');
 
         $listener = new ExternalRedirectListener(true);
         $this->filterResponse($listener, 'http://foo.com/', 'http://bar.com/');
@@ -100,7 +97,7 @@ class ExternalRedirectListenerTest extends \PHPUnit\Framework\TestCase
      */
     public function testRedirectDoesNotSkipNonWhitelistedDomains($whitelist, $domain)
     {
-        $this->expectException(HttpException::class);
+        $this->expectException('Symfony\Component\HttpKernel\Exception\HttpException');
 
         $listener = new ExternalRedirectListener(true, null, null, $whitelist);
 
@@ -148,10 +145,10 @@ class ExternalRedirectListenerTest extends \PHPUnit\Framework\TestCase
 
         $response = new RedirectResponse('http://foo.com/');
 
-        if (class_exists(ResponseEvent::class)) {
-            $class = ResponseEvent::class;
+        if (class_exists('Symfony\Component\HttpKernel\Event\ResponseEvent')) {
+            $class = 'Symfony\Component\HttpKernel\Event\ResponseEvent';
         } else {
-            $class = FilterResponseEvent::class;
+            $class = 'Symfony\Component\HttpKernel\Event\FilterResponseEvent';
         }
 
         $event = new $class($this->kernel, $request, HttpKernelInterface::SUB_REQUEST, $response);
@@ -167,10 +164,10 @@ class ExternalRedirectListenerTest extends \PHPUnit\Framework\TestCase
 
         $response = new RedirectResponse($target);
 
-        if (class_exists(ResponseEvent::class)) {
-            $class = ResponseEvent::class;
+        if (class_exists('Symfony\Component\HttpKernel\Event\ResponseEvent')) {
+            $class = 'Symfony\Component\HttpKernel\Event\ResponseEvent';
         } else {
-            $class = FilterResponseEvent::class;
+            $class = 'Symfony\Component\HttpKernel\Event\FilterResponseEvent';
         }
 
         $event = new $class($this->kernel, $request, HttpKernelInterface::MASTER_REQUEST, $response);

--- a/Tests/Listener/ExternalRedirectListenerTest.php
+++ b/Tests/Listener/ExternalRedirectListenerTest.php
@@ -16,6 +16,7 @@ use Nelmio\SecurityBundle\ExternalRedirect\WhitelistBasedTargetValidator;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpKernel\Event\ResponseEvent;
+use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
 
@@ -61,10 +62,11 @@ class ExternalRedirectListenerTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @depends testRedirectMatcher
-     * @expectedException Symfony\Component\HttpKernel\Exception\HttpException
      */
     public function testRedirectAbort()
     {
+        $this->expectException(HttpException::class);
+
         $listener = new ExternalRedirectListener(true);
         $this->filterResponse($listener, 'http://foo.com/', 'http://bar.com/');
     }
@@ -95,10 +97,11 @@ class ExternalRedirectListenerTest extends \PHPUnit\Framework\TestCase
     /**
      * @depends testRedirectMatcher
      * @dataProvider provideRedirectWhitelistsFailing
-     * @expectedException Symfony\Component\HttpKernel\Exception\HttpException
      */
     public function testRedirectDoesNotSkipNonWhitelistedDomains($whitelist, $domain)
     {
+        $this->expectException(HttpException::class);
+
         $listener = new ExternalRedirectListener(true, null, null, $whitelist);
 
         $this->filterResponse($listener, 'http://foo.com/', 'http://'.$domain.'/');

--- a/Tests/Listener/FlexibleSslListenerTest.php
+++ b/Tests/Listener/FlexibleSslListenerTest.php
@@ -15,11 +15,7 @@ use Nelmio\SecurityBundle\EventListener\FlexibleSslListener;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\ResponseHeaderBag;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpKernel\Event\RequestEvent;
-use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
-use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
-use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 
 class FlexibleSslListenerTest extends \PHPUnit\Framework\TestCase
@@ -39,10 +35,10 @@ class FlexibleSslListenerTest extends \PHPUnit\Framework\TestCase
     {
         $request = Request::create('http://localhost/');
 
-        if (class_exists(RequestEvent::class)) {
-            $class = RequestEvent::class;
+        if (class_exists('Symfony\Component\HttpKernel\Event\RequestEvent')) {
+            $class = 'Symfony\Component\HttpKernel\Event\RequestEvent';
         } else {
-            $class = GetResponseEvent::class;
+            $class = 'Symfony\Component\HttpKernel\Event\GetResponseEvent';
         }
 
         $event = new $class($this->kernel, $request, HttpKernelInterface::MASTER_REQUEST);
@@ -56,10 +52,10 @@ class FlexibleSslListenerTest extends \PHPUnit\Framework\TestCase
         $request = Request::create('http://localhost/');
         $request->cookies->set('auth', '1');
 
-        if (class_exists(RequestEvent::class)) {
-            $class = RequestEvent::class;
+        if (class_exists('Symfony\Component\HttpKernel\Event\RequestEvent')) {
+            $class = 'Symfony\Component\HttpKernel\Event\RequestEvent';
         } else {
-            $class = GetResponseEvent::class;
+            $class = 'Symfony\Component\HttpKernel\Event\GetResponseEvent';
         }
 
         $event = new $class($this->kernel, $request, HttpKernelInterface::MASTER_REQUEST);
@@ -73,10 +69,10 @@ class FlexibleSslListenerTest extends \PHPUnit\Framework\TestCase
     {
         $request = Request::create('https://localhost/');
 
-        if (class_exists(RequestEvent::class)) {
-            $class = RequestEvent::class;
+        if (class_exists('Symfony\Component\HttpKernel\Event\RequestEvent')) {
+            $class = 'Symfony\Component\HttpKernel\Event\RequestEvent';
         } else {
-            $class = GetResponseEvent::class;
+            $class = 'Symfony\Component\HttpKernel\Event\GetResponseEvent';
         }
 
         $event = new $class($this->kernel, $request, HttpKernelInterface::MASTER_REQUEST);
@@ -90,10 +86,10 @@ class FlexibleSslListenerTest extends \PHPUnit\Framework\TestCase
         $request = Request::create('https://localhost/');
         $request->cookies->set('auth', '1');
 
-        if (class_exists(RequestEvent::class)) {
-            $class = RequestEvent::class;
+        if (class_exists('Symfony\Component\HttpKernel\Event\RequestEvent')) {
+            $class = 'Symfony\Component\HttpKernel\Event\RequestEvent';
         } else {
-            $class = GetResponseEvent::class;
+            $class = 'Symfony\Component\HttpKernel\Event\GetResponseEvent';
         }
 
         $event = new $class($this->kernel, $request, HttpKernelInterface::MASTER_REQUEST);
@@ -108,10 +104,10 @@ class FlexibleSslListenerTest extends \PHPUnit\Framework\TestCase
 
         $response = new Response();
 
-        if (class_exists(ResponseEvent::class)) {
-            $class = ResponseEvent::class;
+        if (class_exists('Symfony\Component\HttpKernel\Event\ResponseEvent')) {
+            $class = 'Symfony\Component\HttpKernel\Event\ResponseEvent';
         } else {
-            $class = FilterResponseEvent::class;
+            $class = 'Symfony\Component\HttpKernel\Event\FilterResponseEvent';
         }
 
         $event = new $class($this->kernel, $request, HttpKernelInterface::MASTER_REQUEST, $response);
@@ -132,10 +128,10 @@ class FlexibleSslListenerTest extends \PHPUnit\Framework\TestCase
         $request = Request::create('http://localhost/');
         $request->cookies->set('auth', '1');
 
-        if (class_exists(RequestEvent::class)) {
-            $class = RequestEvent::class;
+        if (class_exists('Symfony\Component\HttpKernel\Event\RequestEvent')) {
+            $class = 'Symfony\Component\HttpKernel\Event\RequestEvent';
         } else {
-            $class = GetResponseEvent::class;
+            $class = 'Symfony\Component\HttpKernel\Event\GetResponseEvent';
         }
 
         $event = new $class($this->kernel, $request, HttpKernelInterface::SUB_REQUEST);
@@ -150,10 +146,10 @@ class FlexibleSslListenerTest extends \PHPUnit\Framework\TestCase
 
         $response = new Response();
 
-        if (class_exists(ResponseEvent::class)) {
-            $class = ResponseEvent::class;
+        if (class_exists('Symfony\Component\HttpKernel\Event\ResponseEvent')) {
+            $class = 'Symfony\Component\HttpKernel\Event\ResponseEvent';
         } else {
-            $class = FilterResponseEvent::class;
+            $class = 'Symfony\Component\HttpKernel\Event\FilterResponseEvent';
         }
 
         $event = new $class($this->kernel, $request, HttpKernelInterface::SUB_REQUEST, $response);

--- a/Tests/Listener/FlexibleSslListenerTest.php
+++ b/Tests/Listener/FlexibleSslListenerTest.php
@@ -15,6 +15,8 @@ use Nelmio\SecurityBundle\EventListener\FlexibleSslListener;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\ResponseHeaderBag;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
@@ -37,7 +39,13 @@ class FlexibleSslListenerTest extends \PHPUnit\Framework\TestCase
     {
         $request = Request::create('http://localhost/');
 
-        $event = new GetResponseEvent($this->kernel, $request, HttpKernelInterface::MASTER_REQUEST);
+        if (class_exists(RequestEvent::class)) {
+            $class = RequestEvent::class;
+        } else {
+            $class = GetResponseEvent::class;
+        }
+
+        $event = new $class($this->kernel, $request, HttpKernelInterface::MASTER_REQUEST);
         $this->listener->onKernelRequest($event);
 
         $this->assertFalse($event->hasResponse());
@@ -48,7 +56,13 @@ class FlexibleSslListenerTest extends \PHPUnit\Framework\TestCase
         $request = Request::create('http://localhost/');
         $request->cookies->set('auth', '1');
 
-        $event = new GetResponseEvent($this->kernel, $request, HttpKernelInterface::MASTER_REQUEST);
+        if (class_exists(RequestEvent::class)) {
+            $class = RequestEvent::class;
+        } else {
+            $class = GetResponseEvent::class;
+        }
+
+        $event = new $class($this->kernel, $request, HttpKernelInterface::MASTER_REQUEST);
         $this->listener->onKernelRequest($event);
 
         $this->assertTrue($event->hasResponse());
@@ -59,7 +73,13 @@ class FlexibleSslListenerTest extends \PHPUnit\Framework\TestCase
     {
         $request = Request::create('https://localhost/');
 
-        $event = new GetResponseEvent($this->kernel, $request, HttpKernelInterface::MASTER_REQUEST);
+        if (class_exists(RequestEvent::class)) {
+            $class = RequestEvent::class;
+        } else {
+            $class = GetResponseEvent::class;
+        }
+
+        $event = new $class($this->kernel, $request, HttpKernelInterface::MASTER_REQUEST);
         $this->listener->onKernelRequest($event);
 
         $this->assertFalse($event->hasResponse());
@@ -70,7 +90,13 @@ class FlexibleSslListenerTest extends \PHPUnit\Framework\TestCase
         $request = Request::create('https://localhost/');
         $request->cookies->set('auth', '1');
 
-        $event = new GetResponseEvent($this->kernel, $request, HttpKernelInterface::MASTER_REQUEST);
+        if (class_exists(RequestEvent::class)) {
+            $class = RequestEvent::class;
+        } else {
+            $class = GetResponseEvent::class;
+        }
+
+        $event = new $class($this->kernel, $request, HttpKernelInterface::MASTER_REQUEST);
         $this->listener->onKernelRequest($event);
 
         $this->assertFalse($event->hasResponse());
@@ -82,7 +108,13 @@ class FlexibleSslListenerTest extends \PHPUnit\Framework\TestCase
 
         $response = new Response();
 
-        $event = new FilterResponseEvent($this->kernel, $request, HttpKernelInterface::MASTER_REQUEST, $response);
+        if (class_exists(ResponseEvent::class)) {
+            $class = ResponseEvent::class;
+        } else {
+            $class = FilterResponseEvent::class;
+        }
+
+        $event = new $class($this->kernel, $request, HttpKernelInterface::MASTER_REQUEST, $response);
         $this->listener->onPostLoginKernelResponse($event);
 
         $cookies = $response->headers->getCookies(ResponseHeaderBag::COOKIES_ARRAY);
@@ -100,7 +132,13 @@ class FlexibleSslListenerTest extends \PHPUnit\Framework\TestCase
         $request = Request::create('http://localhost/');
         $request->cookies->set('auth', '1');
 
-        $event = new GetResponseEvent($this->kernel, $request, HttpKernelInterface::SUB_REQUEST);
+        if (class_exists(RequestEvent::class)) {
+            $class = RequestEvent::class;
+        } else {
+            $class = GetResponseEvent::class;
+        }
+
+        $event = new $class($this->kernel, $request, HttpKernelInterface::SUB_REQUEST);
         $this->listener->onKernelRequest($event);
 
         $this->assertFalse($event->hasResponse());
@@ -112,7 +150,13 @@ class FlexibleSslListenerTest extends \PHPUnit\Framework\TestCase
 
         $response = new Response();
 
-        $event = new FilterResponseEvent($this->kernel, $request, HttpKernelInterface::SUB_REQUEST, $response);
+        if (class_exists(ResponseEvent::class)) {
+            $class = ResponseEvent::class;
+        } else {
+            $class = FilterResponseEvent::class;
+        }
+
+        $event = new $class($this->kernel, $request, HttpKernelInterface::SUB_REQUEST, $response);
         $this->listener->onPostLoginKernelResponse($event);
 
         $cookies = $response->headers->getCookies(ResponseHeaderBag::COOKIES_ARRAY);

--- a/Tests/Listener/ForcedSslListenerTest.php
+++ b/Tests/Listener/ForcedSslListenerTest.php
@@ -14,11 +14,7 @@ namespace Nelmio\SecurityBundle\Tests\Listener;
 use Nelmio\SecurityBundle\EventListener\ForcedSslListener;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpKernel\Event\RequestEvent;
-use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
-use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
-use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 
 class ForcedSslListenerTest extends \PHPUnit\Framework\TestCase
 {
@@ -116,10 +112,10 @@ class ForcedSslListenerTest extends \PHPUnit\Framework\TestCase
     {
         $request = Request::create($uri);
 
-        if (class_exists(RequestEvent::class)) {
-            $class = RequestEvent::class;
+        if (class_exists('Symfony\Component\HttpKernel\Event\RequestEvent')) {
+            $class = 'Symfony\Component\HttpKernel\Event\RequestEvent';
         } else {
-            $class = GetResponseEvent::class;
+            $class = 'Symfony\Component\HttpKernel\Event\GetResponseEvent';
         }
 
         $event = new $class($this->kernel, $request, $masterReq ? HttpKernelInterface::MASTER_REQUEST : HttpKernelInterface::SUB_REQUEST);
@@ -133,10 +129,10 @@ class ForcedSslListenerTest extends \PHPUnit\Framework\TestCase
         $request = Request::create($uri);
         $response = new Response();
 
-        if (class_exists(ResponseEvent::class)) {
-            $class = ResponseEvent::class;
+        if (class_exists('Symfony\Component\HttpKernel\Event\ResponseEvent')) {
+            $class = 'Symfony\Component\HttpKernel\Event\ResponseEvent';
         } else {
-            $class = FilterResponseEvent::class;
+            $class = 'Symfony\Component\HttpKernel\Event\FilterResponseEvent';
         }
 
         $event = new $class($this->kernel, $request, $masterReq ? HttpKernelInterface::MASTER_REQUEST : HttpKernelInterface::SUB_REQUEST, $response);

--- a/Tests/Listener/ForcedSslListenerTest.php
+++ b/Tests/Listener/ForcedSslListenerTest.php
@@ -14,6 +14,8 @@ namespace Nelmio\SecurityBundle\Tests\Listener;
 use Nelmio\SecurityBundle\EventListener\ForcedSslListener;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
@@ -114,7 +116,13 @@ class ForcedSslListenerTest extends \PHPUnit\Framework\TestCase
     {
         $request = Request::create($uri);
 
-        $event = new GetResponseEvent($this->kernel, $request, $masterReq ? HttpKernelInterface::MASTER_REQUEST : HttpKernelInterface::SUB_REQUEST);
+        if (class_exists(RequestEvent::class)) {
+            $class = RequestEvent::class;
+        } else {
+            $class = GetResponseEvent::class;
+        }
+
+        $event = new $class($this->kernel, $request, $masterReq ? HttpKernelInterface::MASTER_REQUEST : HttpKernelInterface::SUB_REQUEST);
         $listener->onKernelRequest($event);
 
         return $event->getResponse();
@@ -125,7 +133,13 @@ class ForcedSslListenerTest extends \PHPUnit\Framework\TestCase
         $request = Request::create($uri);
         $response = new Response();
 
-        $event = new FilterResponseEvent($this->kernel, $request, $masterReq ? HttpKernelInterface::MASTER_REQUEST : HttpKernelInterface::SUB_REQUEST, $response);
+        if (class_exists(ResponseEvent::class)) {
+            $class = ResponseEvent::class;
+        } else {
+            $class = FilterResponseEvent::class;
+        }
+
+        $event = new $class($this->kernel, $request, $masterReq ? HttpKernelInterface::MASTER_REQUEST : HttpKernelInterface::SUB_REQUEST, $response);
         $listener->onKernelResponse($event);
 
         return $response;

--- a/Tests/Listener/ReferrerPolicyListenerTest.php
+++ b/Tests/Listener/ReferrerPolicyListenerTest.php
@@ -14,8 +14,6 @@ namespace Nelmio\SecurityBundle\Tests\Listener;
 use Nelmio\SecurityBundle\EventListener\ReferrerPolicyListener;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
-use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 
 class ReferrerPolicyListenerTest extends \PHPUnit\Framework\TestCase
@@ -52,10 +50,10 @@ class ReferrerPolicyListenerTest extends \PHPUnit\Framework\TestCase
         $request = Request::create($path);
         $response = new Response();
 
-        if (class_exists(ResponseEvent::class)) {
-            $class = ResponseEvent::class;
+        if (class_exists('Symfony\Component\HttpKernel\Event\ResponseEvent')) {
+            $class = 'Symfony\Component\HttpKernel\Event\ResponseEvent';
         } else {
-            $class = FilterResponseEvent::class;
+            $class = 'Symfony\Component\HttpKernel\Event\FilterResponseEvent';
         }
 
         $event = new $class(

--- a/Tests/Listener/ReferrerPolicyListenerTest.php
+++ b/Tests/Listener/ReferrerPolicyListenerTest.php
@@ -15,6 +15,7 @@ use Nelmio\SecurityBundle\EventListener\ReferrerPolicyListener;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 
 class ReferrerPolicyListenerTest extends \PHPUnit\Framework\TestCase
@@ -51,7 +52,13 @@ class ReferrerPolicyListenerTest extends \PHPUnit\Framework\TestCase
         $request = Request::create($path);
         $response = new Response();
 
-        $event = new FilterResponseEvent(
+        if (class_exists(ResponseEvent::class)) {
+            $class = ResponseEvent::class;
+        } else {
+            $class = FilterResponseEvent::class;
+        }
+
+        $event = new $class(
             $this->kernel,
             $request,
             $masterReq ? HttpKernelInterface::MASTER_REQUEST : HttpKernelInterface::SUB_REQUEST,

--- a/Tests/Listener/SignedCookieListenerTest.php
+++ b/Tests/Listener/SignedCookieListenerTest.php
@@ -17,11 +17,7 @@ use Symfony\Component\HttpFoundation\Cookie;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\ResponseHeaderBag;
-use Symfony\Component\HttpKernel\Event\RequestEvent;
-use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
-use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
-use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 
 class SignedCookieListenerTest extends \PHPUnit\Framework\TestCase
 {
@@ -42,10 +38,10 @@ class SignedCookieListenerTest extends \PHPUnit\Framework\TestCase
         $listener = new SignedCookieListener($this->signer, $signedCookieNames);
         $request = Request::create('/', 'GET', array(), $inputCookies);
 
-        if (class_exists(RequestEvent::class)) {
-            $class = RequestEvent::class;
+        if (class_exists('Symfony\Component\HttpKernel\Event\RequestEvent')) {
+            $class = 'Symfony\Component\HttpKernel\Event\RequestEvent';
         } else {
-            $class = GetResponseEvent::class;
+            $class = 'Symfony\Component\HttpKernel\Event\GetResponseEvent';
         }
 
         $event = new $class($this->kernel, $request, HttpKernelInterface::MASTER_REQUEST);
@@ -78,10 +74,10 @@ class SignedCookieListenerTest extends \PHPUnit\Framework\TestCase
             $response->headers->setCookie(method_exists('Symfony\\Component\\HttpFoundation\\Cookie', 'create') ? Cookie::create($name, $cookie) : new Cookie($name, $cookie));
         }
 
-        if (class_exists(ResponseEvent::class)) {
-            $class = ResponseEvent::class;
+        if (class_exists('Symfony\Component\HttpKernel\Event\ResponseEvent')) {
+            $class = 'Symfony\Component\HttpKernel\Event\ResponseEvent';
         } else {
-            $class = FilterResponseEvent::class;
+            $class = 'Symfony\Component\HttpKernel\Event\FilterResponseEvent';
         }
 
         $event = new $class($this->kernel, $request, HttpKernelInterface::MASTER_REQUEST, $response);
@@ -110,10 +106,10 @@ class SignedCookieListenerTest extends \PHPUnit\Framework\TestCase
         $listener = new SignedCookieListener($this->signer, array('*'));
         $request = Request::create('/', 'GET', array(), array('foo' => 'bar'));
 
-        if (class_exists(RequestEvent::class)) {
-            $class = RequestEvent::class;
+        if (class_exists('Symfony\Component\HttpKernel\Event\RequestEvent')) {
+            $class = 'Symfony\Component\HttpKernel\Event\RequestEvent';
         } else {
-            $class = GetResponseEvent::class;
+            $class = 'Symfony\Component\HttpKernel\Event\GetResponseEvent';
         }
 
         $event = new $class($this->kernel, $request, HttpKernelInterface::SUB_REQUEST);
@@ -130,10 +126,10 @@ class SignedCookieListenerTest extends \PHPUnit\Framework\TestCase
         $response = new Response();
         $response->headers->setCookie(method_exists('Symfony\\Component\\HttpFoundation\\Cookie', 'create') ? Cookie::create('foo', 'bar') : new Cookie('foo', 'bar'));
 
-        if (class_exists(ResponseEvent::class)) {
-            $class = ResponseEvent::class;
+        if (class_exists('Symfony\Component\HttpKernel\Event\ResponseEvent')) {
+            $class = 'Symfony\Component\HttpKernel\Event\ResponseEvent';
         } else {
-            $class = FilterResponseEvent::class;
+            $class = 'Symfony\Component\HttpKernel\Event\FilterResponseEvent';
         }
 
         $event = new $class($this->kernel, $request, HttpKernelInterface::SUB_REQUEST, $response);

--- a/Tests/Listener/XssProtectionListenerTest.php
+++ b/Tests/Listener/XssProtectionListenerTest.php
@@ -6,6 +6,7 @@ use Nelmio\SecurityBundle\EventListener\XssProtectionListener;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 
 class XssProtectionListenerTest extends \PHPUnit\Framework\TestCase
@@ -43,7 +44,13 @@ class XssProtectionListenerTest extends \PHPUnit\Framework\TestCase
         $request = Request::create($path);
         $response = new Response();
 
-        $event = new FilterResponseEvent(
+        if (class_exists(ResponseEvent::class)) {
+            $class = ResponseEvent::class;
+        } else {
+            $class = FilterResponseEvent::class;
+        }
+
+        $event = new $class(
             $this->kernel,
             $request,
             $masterReq ? HttpKernelInterface::MASTER_REQUEST : HttpKernelInterface::SUB_REQUEST,

--- a/Tests/Listener/XssProtectionListenerTest.php
+++ b/Tests/Listener/XssProtectionListenerTest.php
@@ -5,8 +5,6 @@ namespace Nelmio\SecurityBundle\Tests\Listener;
 use Nelmio\SecurityBundle\EventListener\XssProtectionListener;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
-use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 
 class XssProtectionListenerTest extends \PHPUnit\Framework\TestCase
@@ -44,10 +42,10 @@ class XssProtectionListenerTest extends \PHPUnit\Framework\TestCase
         $request = Request::create($path);
         $response = new Response();
 
-        if (class_exists(ResponseEvent::class)) {
-            $class = ResponseEvent::class;
+        if (class_exists('Symfony\Component\HttpKernel\Event\ResponseEvent')) {
+            $class = 'Symfony\Component\HttpKernel\Event\ResponseEvent';
         } else {
-            $class = FilterResponseEvent::class;
+            $class = 'Symfony\Component\HttpKernel\Event\FilterResponseEvent';
         }
 
         $event = new $class(

--- a/Tests/Session/CookieSessionHandlerTest.php
+++ b/Tests/Session/CookieSessionHandlerTest.php
@@ -32,19 +32,17 @@ class CookieSessionHandlerTest extends \PHPUnit\Framework\TestCase
         $this->kernel = $this->getMockBuilder('Symfony\Component\HttpKernel\HttpKernelInterface')->getMock();
     }
 
-    /**
-     * @expectedException RuntimeException
-     */
     public function testOpenWithNoRequest()
     {
+        $this->expectException(\RuntimeException::class);
+
         $this->handler->open('foo', 'bar');
     }
 
-    /**
-     * @expectedException RuntimeException
-     */
     public function testReadWithNoRequest()
     {
+        $this->expectException(\RuntimeException::class);
+
         $this->handler->read('foo');
     }
 

--- a/Tests/Session/CookieSessionHandlerTest.php
+++ b/Tests/Session/CookieSessionHandlerTest.php
@@ -14,10 +14,6 @@ namespace Nelmio\SecurityBundle\Tests\Session;
 use Nelmio\SecurityBundle\Session\CookieSessionHandler;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpKernel\Event\GetResponseEvent;
-use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
-use Symfony\Component\HttpKernel\Event\RequestEvent;
-use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 
 class CookieSessionHandlerTest extends \PHPUnit\Framework\TestCase
@@ -34,14 +30,14 @@ class CookieSessionHandlerTest extends \PHPUnit\Framework\TestCase
 
     public function testOpenWithNoRequest()
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException('RuntimeException');
 
         $this->handler->open('foo', 'bar');
     }
 
     public function testReadWithNoRequest()
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException('RuntimeException');
 
         $this->handler->read('foo');
     }
@@ -54,10 +50,10 @@ class CookieSessionHandlerTest extends \PHPUnit\Framework\TestCase
         $session->expects($this->exactly(1))->method('save');
         $request->setSession($session);
 
-        if (class_exists(RequestEvent::class)) {
-            $class = RequestEvent::class;
+        if (class_exists('Symfony\Component\HttpKernel\Event\RequestEvent')) {
+            $class = 'Symfony\Component\HttpKernel\Event\RequestEvent';
         } else {
-            $class = GetResponseEvent::class;
+            $class = 'Symfony\Component\HttpKernel\Event\GetResponseEvent';
         }
 
         $this->handler->onKernelRequest(new $class($this->kernel, $request, HttpKernelInterface::MASTER_REQUEST));
@@ -66,10 +62,10 @@ class CookieSessionHandlerTest extends \PHPUnit\Framework\TestCase
 
         $this->handler->write('sessionId', 'mydata');
 
-        if (class_exists(ResponseEvent::class)) {
-            $class = ResponseEvent::class;
+        if (class_exists('Symfony\Component\HttpKernel\Event\ResponseEvent')) {
+            $class = 'Symfony\Component\HttpKernel\Event\ResponseEvent';
         } else {
-            $class = FilterResponseEvent::class;
+            $class = 'Symfony\Component\HttpKernel\Event\FilterResponseEvent';
         }
 
         $this->handler->onKernelResponse(new $class($this->kernel, $request, HttpKernelInterface::MASTER_REQUEST, $response));
@@ -91,18 +87,18 @@ class CookieSessionHandlerTest extends \PHPUnit\Framework\TestCase
         $session->expects($this->exactly(2))->method('save');
         $request->setSession($session);
 
-        if (class_exists(RequestEvent::class)) {
-            $class = RequestEvent::class;
+        if (class_exists('Symfony\Component\HttpKernel\Event\RequestEvent')) {
+            $class = 'Symfony\Component\HttpKernel\Event\RequestEvent';
         } else {
-            $class = GetResponseEvent::class;
+            $class = 'Symfony\Component\HttpKernel\Event\GetResponseEvent';
         }
 
         $this->handler->onKernelRequest(new $class($this->kernel, $request, HttpKernelInterface::MASTER_REQUEST));
 
-        if (class_exists(ResponseEvent::class)) {
-            $class = ResponseEvent::class;
+        if (class_exists('Symfony\Component\HttpKernel\Event\ResponseEvent')) {
+            $class = 'Symfony\Component\HttpKernel\Event\ResponseEvent';
         } else {
-            $class = FilterResponseEvent::class;
+            $class = 'Symfony\Component\HttpKernel\Event\FilterResponseEvent';
         }
 
         $this->handler->onKernelResponse(new $class($this->kernel, $request, HttpKernelInterface::MASTER_REQUEST, $response));
@@ -115,10 +111,10 @@ class CookieSessionHandlerTest extends \PHPUnit\Framework\TestCase
 
         $this->handler->destroy('sessionId');
 
-        if (class_exists(ResponseEvent::class)) {
-            $class = ResponseEvent::class;
+        if (class_exists('Symfony\Component\HttpKernel\Event\ResponseEvent')) {
+            $class = 'Symfony\Component\HttpKernel\Event\ResponseEvent';
         } else {
-            $class = FilterResponseEvent::class;
+            $class = 'Symfony\Component\HttpKernel\Event\FilterResponseEvent';
         }
 
         $this->handler->onKernelResponse(new $class($this->kernel, $request, HttpKernelInterface::MASTER_REQUEST, $response));
@@ -149,18 +145,18 @@ class CookieSessionHandlerTest extends \PHPUnit\Framework\TestCase
         $request->setSession($session);
         $response->headers = $headers;
 
-        if (class_exists(RequestEvent::class)) {
-            $class = RequestEvent::class;
+        if (class_exists('Symfony\Component\HttpKernel\Event\RequestEvent')) {
+            $class = 'Symfony\Component\HttpKernel\Event\RequestEvent';
         } else {
-            $class = GetResponseEvent::class;
+            $class = 'Symfony\Component\HttpKernel\Event\GetResponseEvent';
         }
 
         $this->handler->onKernelRequest(new $class($this->kernel, $request, HttpKernelInterface::MASTER_REQUEST));
 
-        if (class_exists(ResponseEvent::class)) {
-            $class = ResponseEvent::class;
+        if (class_exists('Symfony\Component\HttpKernel\Event\ResponseEvent')) {
+            $class = 'Symfony\Component\HttpKernel\Event\ResponseEvent';
         } else {
-            $class = FilterResponseEvent::class;
+            $class = 'Symfony\Component\HttpKernel\Event\FilterResponseEvent';
         }
 
         $this->handler->onKernelResponse(new $class($this->kernel, $request, HttpKernelInterface::MASTER_REQUEST, $response));

--- a/Tests/Session/CookieSessionHandlerTest.php
+++ b/Tests/Session/CookieSessionHandlerTest.php
@@ -16,6 +16,8 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 
 class CookieSessionHandlerTest extends \PHPUnit\Framework\TestCase
@@ -54,12 +56,25 @@ class CookieSessionHandlerTest extends \PHPUnit\Framework\TestCase
         $session->expects($this->exactly(1))->method('save');
         $request->setSession($session);
 
-        $this->handler->onKernelRequest(new GetResponseEvent($this->kernel, $request, HttpKernelInterface::MASTER_REQUEST));
+        if (class_exists(RequestEvent::class)) {
+            $class = RequestEvent::class;
+        } else {
+            $class = GetResponseEvent::class;
+        }
+
+        $this->handler->onKernelRequest(new $class($this->kernel, $request, HttpKernelInterface::MASTER_REQUEST));
 
         $this->assertTrue($this->handler->open('foo', 'bar'));
 
         $this->handler->write('sessionId', 'mydata');
-        $this->handler->onKernelResponse(new FilterResponseEvent($this->kernel, $request, HttpKernelInterface::MASTER_REQUEST, $response));
+
+        if (class_exists(ResponseEvent::class)) {
+            $class = ResponseEvent::class;
+        } else {
+            $class = FilterResponseEvent::class;
+        }
+
+        $this->handler->onKernelResponse(new $class($this->kernel, $request, HttpKernelInterface::MASTER_REQUEST, $response));
 
         $cookies = $response->headers->getCookies();
 
@@ -78,8 +93,21 @@ class CookieSessionHandlerTest extends \PHPUnit\Framework\TestCase
         $session->expects($this->exactly(2))->method('save');
         $request->setSession($session);
 
-        $this->handler->onKernelRequest(new GetResponseEvent($this->kernel, $request, HttpKernelInterface::MASTER_REQUEST));
-        $this->handler->onKernelResponse(new FilterResponseEvent($this->kernel, $request, HttpKernelInterface::MASTER_REQUEST, $response));
+        if (class_exists(RequestEvent::class)) {
+            $class = RequestEvent::class;
+        } else {
+            $class = GetResponseEvent::class;
+        }
+
+        $this->handler->onKernelRequest(new $class($this->kernel, $request, HttpKernelInterface::MASTER_REQUEST));
+
+        if (class_exists(ResponseEvent::class)) {
+            $class = ResponseEvent::class;
+        } else {
+            $class = FilterResponseEvent::class;
+        }
+
+        $this->handler->onKernelResponse(new $class($this->kernel, $request, HttpKernelInterface::MASTER_REQUEST, $response));
 
         $cookies = $response->headers->getCookies();
 
@@ -89,7 +117,13 @@ class CookieSessionHandlerTest extends \PHPUnit\Framework\TestCase
 
         $this->handler->destroy('sessionId');
 
-        $this->handler->onKernelResponse(new FilterResponseEvent($this->kernel, $request, HttpKernelInterface::MASTER_REQUEST, $response));
+        if (class_exists(ResponseEvent::class)) {
+            $class = ResponseEvent::class;
+        } else {
+            $class = FilterResponseEvent::class;
+        }
+
+        $this->handler->onKernelResponse(new $class($this->kernel, $request, HttpKernelInterface::MASTER_REQUEST, $response));
 
         $cookies = $response->headers->getCookies();
 
@@ -117,7 +151,20 @@ class CookieSessionHandlerTest extends \PHPUnit\Framework\TestCase
         $request->setSession($session);
         $response->headers = $headers;
 
-        $this->handler->onKernelRequest(new GetResponseEvent($this->kernel, $request, HttpKernelInterface::MASTER_REQUEST));
-        $this->handler->onKernelResponse(new FilterResponseEvent($this->kernel, $request, HttpKernelInterface::MASTER_REQUEST, $response));
+        if (class_exists(RequestEvent::class)) {
+            $class = RequestEvent::class;
+        } else {
+            $class = GetResponseEvent::class;
+        }
+
+        $this->handler->onKernelRequest(new $class($this->kernel, $request, HttpKernelInterface::MASTER_REQUEST));
+
+        if (class_exists(ResponseEvent::class)) {
+            $class = ResponseEvent::class;
+        } else {
+            $class = FilterResponseEvent::class;
+        }
+
+        $this->handler->onKernelResponse(new $class($this->kernel, $request, HttpKernelInterface::MASTER_REQUEST, $response));
     }
 }

--- a/Tests/SignerTest.php
+++ b/Tests/SignerTest.php
@@ -15,11 +15,10 @@ use Nelmio\SecurityBundle\Signer;
 
 class SignerTest extends \PHPUnit\Framework\TestCase
 {
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testConstructorShouldVerifyHashAlgo()
     {
+        $this->expectException(\InvalidArgumentException::class);
+
         new Signer('secret', 'invalid_hash_algo');
     }
 

--- a/Tests/SignerTest.php
+++ b/Tests/SignerTest.php
@@ -17,7 +17,7 @@ class SignerTest extends \PHPUnit\Framework\TestCase
 {
     public function testConstructorShouldVerifyHashAlgo()
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException('InvalidArgumentException');
 
         new Signer('secret', 'invalid_hash_algo');
     }

--- a/Tests/Twig/IntegrationTest.php
+++ b/Tests/Twig/IntegrationTest.php
@@ -38,7 +38,7 @@ class IntegrationTest extends \PHPUnit\Framework\TestCase
                 $collectedShas['style-src'][] = $shaComputer->computeForStyle($style);
             }));
 
-        if (class_exists(Environment::class)) {
+        if (class_exists('Twig\Environment')) {
             $twig = new Environment(new FilesystemLoader(__DIR__.'/templates'));
         } else {
             $twig = new \Twig_Environment(new \Twig_Loader_Filesystem(__DIR__.'/templates'));

--- a/Tests/Twig/IntegrationTest.php
+++ b/Tests/Twig/IntegrationTest.php
@@ -3,6 +3,8 @@
 namespace Nelmio\SecurityBundle\Tests\Twig;
 
 use Nelmio\SecurityBundle\Twig\NelmioCSPTwigExtension;
+use Twig\Environment;
+use Twig\Loader\FilesystemLoader;
 
 class IntegrationTest extends \PHPUnit\Framework\TestCase
 {
@@ -36,7 +38,12 @@ class IntegrationTest extends \PHPUnit\Framework\TestCase
                 $collectedShas['style-src'][] = $shaComputer->computeForStyle($style);
             }));
 
-        $twig = new \Twig_Environment(new \Twig_Loader_Filesystem(__DIR__.'/templates'));
+        if (class_exists(Environment::class)) {
+            $twig = new Environment(new FilesystemLoader(__DIR__.'/templates'));
+        } else {
+            $twig = new \Twig_Environment(new \Twig_Loader_Filesystem(__DIR__.'/templates'));
+        }
+
         $twig->addExtension(new NelmioCSPTwigExtension($listener, $shaComputer));
 
         $this->assertSame('<script type="text/javascript">console.log(\'123456\');</script>

--- a/Tests/Twig/IntegrationTest.php
+++ b/Tests/Twig/IntegrationTest.php
@@ -38,12 +38,7 @@ class IntegrationTest extends \PHPUnit\Framework\TestCase
                 $collectedShas['style-src'][] = $shaComputer->computeForStyle($style);
             }));
 
-        if (class_exists('Twig\Environment')) {
-            $twig = new Environment(new FilesystemLoader(__DIR__.'/templates'));
-        } else {
-            $twig = new \Twig_Environment(new \Twig_Loader_Filesystem(__DIR__.'/templates'));
-        }
-
+        $twig = new Environment(new FilesystemLoader(__DIR__.'/templates'));
         $twig->addExtension(new NelmioCSPTwigExtension($listener, $shaComputer));
 
         $this->assertSame('<script type="text/javascript">console.log(\'123456\');</script>
@@ -81,12 +76,7 @@ class IntegrationTest extends \PHPUnit\Framework\TestCase
         $listener->expects($this->never())
             ->method('addStyle');
 
-        if (class_exists('Twig\Environment')) {
-            $twig = new Environment(new FilesystemLoader(__DIR__.'/templates'));
-        } else {
-            $twig = new \Twig_Environment(new \Twig_Loader_Filesystem(__DIR__.'/templates'));
-        }
-
+        $twig = new Environment(new FilesystemLoader(__DIR__.'/templates'));
         $twig->addExtension(new NelmioCSPTwigExtension($listener, $shaComputer));
 
         $this->assertSame('<script type="text/javascript">console.log(\'Hello\');</script>

--- a/Tests/Twig/IntegrationTest.php
+++ b/Tests/Twig/IntegrationTest.php
@@ -81,7 +81,12 @@ class IntegrationTest extends \PHPUnit\Framework\TestCase
         $listener->expects($this->never())
             ->method('addStyle');
 
-        $twig = new \Twig_Environment(new \Twig_Loader_Filesystem(__DIR__.'/templates'));
+        if (class_exists('Twig\Environment')) {
+            $twig = new Environment(new FilesystemLoader(__DIR__.'/templates'));
+        } else {
+            $twig = new \Twig_Environment(new \Twig_Loader_Filesystem(__DIR__.'/templates'));
+        }
+
         $twig->addExtension(new NelmioCSPTwigExtension($listener, $shaComputer));
 
         $this->assertSame('<script type="text/javascript">console.log(\'Hello\');</script>

--- a/Twig/NelmioCSPTwigExtension.php
+++ b/Twig/NelmioCSPTwigExtension.php
@@ -15,8 +15,10 @@ use Nelmio\SecurityBundle\ContentSecurityPolicy\ShaComputer;
 use Nelmio\SecurityBundle\EventListener\ContentSecurityPolicyListener;
 use Nelmio\SecurityBundle\Twig\TokenParser\CSPScriptParser;
 use Nelmio\SecurityBundle\Twig\TokenParser\CSPStyleParser;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
 
-class NelmioCSPTwigExtension extends \Twig_Extension
+class NelmioCSPTwigExtension extends AbstractExtension
 {
     private $listener;
     private $shaComputer;
@@ -45,7 +47,7 @@ class NelmioCSPTwigExtension extends \Twig_Extension
     public function getFunctions()
     {
         return array(
-            new \Twig_SimpleFunction('csp_nonce', array($this, 'getCSPNonce')),
+            new TwigFunction('csp_nonce', array($this, 'getCSPNonce')),
         );
     }
 

--- a/Twig/Node/CSPNode.php
+++ b/Twig/Node/CSPNode.php
@@ -11,19 +11,22 @@ namespace Nelmio\SecurityBundle\Twig\Node;
  * file that was distributed with this source code.
  */
 
-class CSPNode extends \Twig_Node
+use Twig\Compiler;
+use Twig\Node\Node;
+
+class CSPNode extends Node
 {
     private $sha;
     private $directive;
 
-    public function __construct(\Twig_Node $body, $lineno, $tag, $directive, $sha = null)
+    public function __construct(Node $body, $lineno, $tag, $directive, $sha = null)
     {
         parent::__construct(array('body' => $body), array(), $lineno, $tag);
         $this->sha = $sha;
         $this->directive = $directive;
     }
 
-    public function compile(\Twig_Compiler $compiler)
+    public function compile(Compiler $compiler)
     {
         $body = $this->getNode('body');
 

--- a/Twig/TokenParser/AbstractCSPParser.php
+++ b/Twig/TokenParser/AbstractCSPParser.php
@@ -13,8 +13,11 @@ namespace Nelmio\SecurityBundle\Twig\TokenParser;
 
 use Nelmio\SecurityBundle\ContentSecurityPolicy\ShaComputer;
 use Nelmio\SecurityBundle\Twig\Node\CSPNode;
+use Twig\Node\TextNode;
+use Twig\Token;
+use Twig\TokenParser\AbstractTokenParser;
 
-abstract class AbstractCSPParser extends \Twig_TokenParser
+abstract class AbstractCSPParser extends AbstractTokenParser
 {
     protected $shaComputer;
     private $directive;
@@ -27,23 +30,23 @@ abstract class AbstractCSPParser extends \Twig_TokenParser
         $this->directive = $directive;
     }
 
-    public function parse(\Twig_Token $token)
+    public function parse(Token $token)
     {
         $lineno = $token->getLine();
 
-        $this->parser->getStream()->expect(\Twig_Token::BLOCK_END_TYPE);
+        $this->parser->getStream()->expect(Token::BLOCK_END_TYPE);
         $body = $this->parser->subparse(array($this, 'decideCSPScriptEnd'), true);
-        $this->parser->getStream()->expect(\Twig_Token::BLOCK_END_TYPE);
+        $this->parser->getStream()->expect(Token::BLOCK_END_TYPE);
 
         $sha = null;
-        if ($body instanceof \Twig_Node_Text) {
+        if ($body instanceof TextNode) {
             $sha = $this->computeSha($body->getAttribute('data'));
         }
 
         return new CSPNode($body, $lineno, $this->tag, $this->directive, $sha);
     }
 
-    public function decideCSPScriptEnd(\Twig_Token $token)
+    public function decideCSPScriptEnd(Token $token)
     {
         return $token->test('end'.$this->tag);
     }

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     "require-dev": {
         "doctrine/cache": "^1.0",
         "psr/cache": "^1.0",
-        "twig/twig": "^1.24|^2.10",
+        "twig/twig": "^1.38|^2.10",
         "symfony/yaml": "~2.3|~3.0|~4.0|~5.0",
         "symfony/phpunit-bridge": "~5.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "psr/cache": "^1.0",
         "twig/twig": "^1.24|^2.10",
         "symfony/yaml": "~2.3|~3.0|~4.0|~5.0",
-        "symfony/phpunit-bridge": "^3.4.24|~4.0|~5.0"
+        "symfony/phpunit-bridge": "~5.0"
     },
     "suggest": {
         "ua-parser/uap-php": "To allow adapt CSP directives given the user-agent"

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "psr/cache": "^1.0",
         "twig/twig": "^1.24|^2.10",
         "symfony/yaml": "~2.3|~3.0|~4.0|~5.0",
-        "symfony/phpunit-bridge": "^4.2|~5.0"
+        "symfony/phpunit-bridge": "~5.0"
     },
     "suggest": {
         "ua-parser/uap-php": "To allow adapt CSP directives given the user-agent"

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     "require-dev": {
         "doctrine/cache": "^1.0",
         "psr/cache": "^1.0",
-        "twig/twig": "^1.38|^2.10",
+        "twig/twig": "^1.38|^2.10|^3.0",
         "symfony/yaml": "~2.3|~3.0|~4.0|~5.0",
         "symfony/phpunit-bridge": "~5.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "psr/cache": "^1.0",
         "twig/twig": "^1.24|^2.10",
         "symfony/yaml": "~2.3|~3.0|~4.0|~5.0",
-        "symfony/phpunit-bridge": "~5.0"
+        "symfony/phpunit-bridge": "^4.2|~5.0"
     },
     "suggest": {
         "ua-parser/uap-php": "To allow adapt CSP directives given the user-agent"

--- a/composer.json
+++ b/composer.json
@@ -17,16 +17,18 @@
     "require": {
         "php": ">5.4",
         "paragonie/random_compat": "~1.0|~2.0|9.99.99",
-        "symfony/framework-bundle": "~2.3|~3.0|~4.0",
-        "symfony/security": "~2.3|~3.0|~4.0",
+        "symfony/framework-bundle": "~2.3|~v3.0|~4.0|~5.0",
+        "symfony/security-core": "~2.3|~3.0|~4.0|~5.0",
+        "symfony/security-http": "~2.3|~3.0|~4.0|~5.0",
+        "symfony/security-csrf": "~2.3|~3.0|~4.0|~5.0",
         "ua-parser/uap-php": "^3.4.4"
     },
     "require-dev": {
         "doctrine/cache": "^1.0",
         "psr/cache": "^1.0",
-        "twig/twig": "^1.24",
-        "symfony/yaml": "~2.3|~3.0|~4.0",
-        "symfony/phpunit-bridge": "~5.0"
+        "twig/twig": "^1.24|^2.10",
+        "symfony/yaml": "~2.3|~3.0|~4.0|~5.0",
+        "symfony/phpunit-bridge": "^3.4.24|~4.0|~5.0"
     },
     "suggest": {
         "ua-parser/uap-php": "To allow adapt CSP directives given the user-agent"


### PR DESCRIPTION
This PR supersede #209 as the logic is different, here we keep support for all versions by using `class_exists` a lot.

Thanks to @lyrixx I discovered that the `setUp() : void` from PHPUnit issue is normally managed by the PHPUnit Bridge! :heart_eyes: 

