### PR TITLE
Twig 3 compatibility

### DIFF
--- a/Tests/Twig/IntegrationTest.php
+++ b/Tests/Twig/IntegrationTest.php
@@ -3,6 +3,8 @@
 namespace Nelmio\SecurityBundle\Tests\Twig;
 
 use Nelmio\SecurityBundle\Twig\NelmioCSPTwigExtension;
+use Twig\Environment;
+use Twig\Loader\FilesystemLoader;
 
 class IntegrationTest extends \PHPUnit\Framework\TestCase
 {
@@ -36,7 +38,7 @@ class IntegrationTest extends \PHPUnit\Framework\TestCase
                 $collectedShas['style-src'][] = $shaComputer->computeForStyle($style);
             }));
 
-        $twig = new \Twig_Environment(new \Twig_Loader_Filesystem(__DIR__.'/templates'));
+        $twig = new Environment(new FilesystemLoader(__DIR__.'/templates'));
         $twig->addExtension(new NelmioCSPTwigExtension($listener, $shaComputer));
 
         $this->assertSame('<script type="text/javascript">console.log(\'123456\');</script>
@@ -74,7 +76,7 @@ class IntegrationTest extends \PHPUnit\Framework\TestCase
         $listener->expects($this->never())
             ->method('addStyle');
 
-        $twig = new \Twig_Environment(new \Twig_Loader_Filesystem(__DIR__.'/templates'));
+        $twig = new Environment(new FilesystemLoader(__DIR__.'/templates'));
         $twig->addExtension(new NelmioCSPTwigExtension($listener, $shaComputer));
 
         $this->assertSame('<script type="text/javascript">console.log(\'Hello\');</script>

--- a/Twig/NelmioCSPTwigExtension.php
+++ b/Twig/NelmioCSPTwigExtension.php
@@ -15,8 +15,10 @@ use Nelmio\SecurityBundle\ContentSecurityPolicy\ShaComputer;
 use Nelmio\SecurityBundle\EventListener\ContentSecurityPolicyListener;
 use Nelmio\SecurityBundle\Twig\TokenParser\CSPScriptParser;
 use Nelmio\SecurityBundle\Twig\TokenParser\CSPStyleParser;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
 
-class NelmioCSPTwigExtension extends \Twig_Extension
+class NelmioCSPTwigExtension extends AbstractExtension
 {
     private $listener;
     private $shaComputer;
@@ -45,7 +47,7 @@ class NelmioCSPTwigExtension extends \Twig_Extension
     public function getFunctions()
     {
         return array(
-            new \Twig_SimpleFunction('csp_nonce', array($this, 'getCSPNonce')),
+            new TwigFunction('csp_nonce', array($this, 'getCSPNonce')),
         );
     }
 

--- a/Twig/Node/CSPNode.php
+++ b/Twig/Node/CSPNode.php
@@ -11,19 +11,22 @@ namespace Nelmio\SecurityBundle\Twig\Node;
  * file that was distributed with this source code.
  */
 
-class CSPNode extends \Twig_Node
+use Twig\Compiler;
+use Twig\Node\Node;
+
+class CSPNode extends Node
 {
     private $sha;
     private $directive;
 
-    public function __construct(\Twig_Node $body, $lineno, $tag, $directive, $sha = null)
+    public function __construct(Node $body, $lineno, $tag, $directive, $sha = null)
     {
         parent::__construct(array('body' => $body), array(), $lineno, $tag);
         $this->sha = $sha;
         $this->directive = $directive;
     }
 
-    public function compile(\Twig_Compiler $compiler)
+    public function compile(Compiler $compiler)
     {
         $body = $this->getNode('body');
 

--- a/Twig/TokenParser/AbstractCSPParser.php
+++ b/Twig/TokenParser/AbstractCSPParser.php
@@ -13,8 +13,11 @@ namespace Nelmio\SecurityBundle\Twig\TokenParser;
 
 use Nelmio\SecurityBundle\ContentSecurityPolicy\ShaComputer;
 use Nelmio\SecurityBundle\Twig\Node\CSPNode;
+use Twig\Node\TextNode;
+use Twig\Token;
+use Twig\TokenParser\AbstractTokenParser;
 
-abstract class AbstractCSPParser extends \Twig_TokenParser
+abstract class AbstractCSPParser extends AbstractTokenParser
 {
     protected $shaComputer;
     private $directive;
@@ -27,23 +30,23 @@ abstract class AbstractCSPParser extends \Twig_TokenParser
         $this->directive = $directive;
     }
 
-    public function parse(\Twig_Token $token)
+    public function parse(Token $token)
     {
         $lineno = $token->getLine();
 
-        $this->parser->getStream()->expect(\Twig_Token::BLOCK_END_TYPE);
+        $this->parser->getStream()->expect(Token::BLOCK_END_TYPE);
         $body = $this->parser->subparse(array($this, 'decideCSPScriptEnd'), true);
-        $this->parser->getStream()->expect(\Twig_Token::BLOCK_END_TYPE);
+        $this->parser->getStream()->expect(Token::BLOCK_END_TYPE);
 
         $sha = null;
-        if ($body instanceof \Twig_Node_Text) {
+        if ($body instanceof TextNode) {
             $sha = $this->computeSha($body->getAttribute('data'));
         }
 
         return new CSPNode($body, $lineno, $this->tag, $this->directive, $sha);
     }
 
-    public function decideCSPScriptEnd(\Twig_Token $token)
+    public function decideCSPScriptEnd(Token $token)
     {
         return $token->test('end'.$this->tag);
     }


### PR DESCRIPTION
Following my issue #212, I made the few needed changes for Twig 3 compatibility. Twig 2 and newer versions of Twig 1 also work with the new namespaced classes, just the aliases were removed in Twig 3.