### PR TITLE
show non-deprecated usage of the csp_nonce Twig function

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,13 +362,13 @@ In your Twig template use the `csp_nonce` function to access the nonce for the c
 CSP header. If you do not request a nonce, nonce will not be generated.
 
 ```twig
-<script nonce="{{ csp_nonce() }}">
+<script nonce="{{ csp_nonce('script') }}">
     window.api_key = '{{ api_key }}';
 </script>
 
 // ...
 
-<style nonce="{{ csp_nonce() }}">
+<style nonce="{{ csp_nonce('style') }}">
     body {
         background-color: '{{ bgColor }}';
     }


### PR DESCRIPTION
Not specifying the usage of the nonce is deprecated, so the readme should provide the usage when documenting the Twig function.