### PR TITLE
Optimize regular expressions in the sha computer

### DIFF
--- a/ContentSecurityPolicy/ShaComputer.php
+++ b/ContentSecurityPolicy/ShaComputer.php
@@ -27,11 +27,11 @@ class ShaComputer
 
     public function computeForScript($html)
     {
-        if (1 !== preg_match_all('/<script[^>]*>/i', $html, $m)) {
+        if (1 !== preg_match_all('/<script[^>]*+>/i', $html, $m)) {
             throw new \InvalidArgumentException('Invalid script, you should use a single <script> tag.');
         }
 
-        preg_match('/^\s*<script[^>]*>((?s).*)<\/script>\s*$/i', $html, $matches);
+        preg_match('/^\s*+<script[^>]*+>((?s).*)<\/script>\s*+$/i', $html, $matches);
 
         if (!isset($matches[1])) {
             throw new \InvalidArgumentException('Invalid script, no <script> tag found.');
@@ -42,11 +42,11 @@ class ShaComputer
 
     public function computeForStyle($html)
     {
-        if (1 !== preg_match_all('/<style[^>]*>/i', $html, $m)) {
+        if (1 !== preg_match_all('/<style[^>]*+>/i', $html, $m)) {
             throw new \InvalidArgumentException('Invalid script, you should use a single <style> tag.');
         }
 
-        preg_match('/^\s*<style[^>]*>((?s).*)<\/style>\s*$/i', $html, $matches);
+        preg_match('/^\s*+<style[^>]*+>((?s).*)<\/style>\s*+$/i', $html, $matches);
 
         if (!isset($matches[1])) {
             throw new \InvalidArgumentException('Invalid script, no <style> tag found.');


### PR DESCRIPTION
This uses possessive quantifiers whenever possible, to prevent useless backtracking.

Note that PCRE might be smart enough to guess these automatically (these are all cases of a repetition of chars followed by a char not allowed by the repetition), but I'm not sure it actually does such optimization automatically today. So this forces the optimization to be applied.