### PR TITLE
Fix the ClassNotFoundError Exception

### DIFF
--- a/ContentSecurityPolicy/Violation/Event.php
+++ b/ContentSecurityPolicy/Violation/Event.php
@@ -11,7 +11,21 @@
 
 namespace Nelmio\SecurityBundle\ContentSecurityPolicy\Violation;
 
-use Symfony\Component\EventDispatcher\Event as BaseEvent;
+if (\class_exists(\Symfony\Component\EventDispatcher\Event::class)) {
+    /**
+     * @internal
+     */
+    class BaseEvent extends \Symfony\Component\EventDispatcher\Event
+    {
+    }
+} else {
+    /**
+     * @internal
+     */
+    class BaseEvent extends \Symfony\Contracts\EventDispatcher\Event
+    {
+    }
+}
 
 class Event extends BaseEvent
 {

--- a/Tests/ContentSecurityPolicy/Violation/EventTest.php
+++ b/Tests/ContentSecurityPolicy/Violation/EventTest.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace ContentSecurityPolicy\Violation;
+
+use Nelmio\SecurityBundle\ContentSecurityPolicy\Violation\Event;
+use Nelmio\SecurityBundle\ContentSecurityPolicy\Violation\Report;
+use PhpUnit\Framework\TestCase;
+
+class EventTest extends TestCase
+{
+    public function testCanBeConstructed()
+    {
+        $this->assertInstanceOf(
+            Event::class,
+            new Event(new Report([]))
+        );
+    }
+}


### PR DESCRIPTION
* The Nelmio\SecurityBundle\ContentSecurityPolicy\Violation\Event class extends
  from the Symfony\Component\EventDispatcher\Event class. This class has been removed
  and needs to be replaced with Symfony\Contracts\EventDispatcher
* In the ContentSecurityPolicyController the event dispatcher has a different signature
  starting from version 4.3. Keep this version in mind to switch the argument list

I'm not using the LegacyEventDispatcherProxy because this will be deprecated in Symfony 5 this method signature changes again.