### PR TITLE
Adding missing type conversion as parse requires string.

### DIFF
--- a/UserAgent/UAFamilyParser/UAFamilyParser.php
+++ b/UserAgent/UAFamilyParser/UAFamilyParser.php
@@ -24,6 +24,7 @@ class UAFamilyParser implements UAFamilyParserInterface
 
     public function getUaFamily($userAgent)
     {
+        if ($userAgent === null) $userAgent = '';
         return strtolower($this->parser->parse($userAgent)->ua->family);
     }
 }


### PR DESCRIPTION
Fatal error was thrown on missing user-agent header.