### PR TITLE
Trusted types

### DIFF
--- a/ContentSecurityPolicy/ContentSecurityPolicyParser.php
+++ b/ContentSecurityPolicy/ContentSecurityPolicyParser.php
@@ -22,6 +22,8 @@ class ContentSecurityPolicyParser
         'report-sample',
         'unsafe-allow-redirects',
         'none',
+        'script',
+        'style'
     );
 
     /**

--- a/ContentSecurityPolicy/DirectiveSet.php
+++ b/ContentSecurityPolicy/DirectiveSet.php
@@ -21,6 +21,7 @@ class DirectiveSet
     const TYPE_ANCESTOR_SRC_LIST = 'ancestor-source-list';
     const TYPE_URI_REFERENCE = 'uri-reference';
     const TYPE_NO_VALUE = 'no-value';
+    const TYPE_POLICIES_LIST = "policies-list";
 
     private static $directiveNames = array(
         'default-src' => self::TYPE_SRC_LIST,
@@ -42,6 +43,8 @@ class DirectiveSet
         'upgrade-insecure-requests' => self::TYPE_NO_VALUE,
         'report-uri' => self::TYPE_URI_REFERENCE,
         'worker-src' => self::TYPE_SRC_LIST,
+        'trusted-types' => self::TYPE_POLICIES_LIST,
+        'require-trusted-types-for' => self::TYPE_POLICIES_LIST
     );
 
     private $directiveValues = array();

--- a/ContentSecurityPolicy/PolicyManager.php
+++ b/ContentSecurityPolicy/PolicyManager.php
@@ -107,6 +107,8 @@ class PolicyManager
                 'manifest-src',
                 'reflected-xss',
                 'worker-src',
+                'trusted-types',
+                'require-trusted-types-for'
             ));
         }
 

--- a/ContentSecurityPolicy/PolicyManager.php
+++ b/ContentSecurityPolicy/PolicyManager.php
@@ -50,7 +50,10 @@ class PolicyManager
 
     private function getChromeDirectives()
     {
-        return array_merge($this->getLevel3(), $this->getDraftDirectives());
+        return array_merge($this->getLevel3(), $this->getDraftDirectives(), array(
+            'trusted-types',
+            'require-trusted-types-for'
+        ));
     }
 
     private function getFirefoxDirectives()
@@ -107,8 +110,6 @@ class PolicyManager
                 'manifest-src',
                 'reflected-xss',
                 'worker-src',
-                'trusted-types',
-                'require-trusted-types-for'
             ));
         }
 

--- a/Tests/ContentSecurityPolicy/ContentSecurityPolicyParserTest.php
+++ b/Tests/ContentSecurityPolicy/ContentSecurityPolicyParserTest.php
@@ -34,6 +34,8 @@ class ContentSecurityPolicyParserTest extends \PHPUnit\Framework\TestCase
             array('http://example.com', 'http://example.com'),
             array('http://example.com:81', 'http://example.com:81'),
             array('https://example.com', 'https://example.com'),
+            array("script", "'script'"),
+            array("style", "'style'")
         );
     }
 }

--- a/Tests/ContentSecurityPolicy/DirectiveSetTest.php
+++ b/Tests/ContentSecurityPolicy/DirectiveSetTest.php
@@ -56,7 +56,9 @@ class DirectiveSetTest extends \PHPUnit\Framework\TestCase
                 'style-src style.example.org \'self\'; '.
                 'upgrade-insecure-requests; '.
                 'report-uri http://report-uri; '.
-                'worker-src worker.example.com \'self\'',
+                'worker-src worker.example.com \'self\'; '.
+                'trusted-types foo; '.
+                'require-trusted-types-for \'script\'',
                 self::UA_CHROME,
                 array(
                     'default-src' => array('example.org', "'self'"),
@@ -76,6 +78,8 @@ class DirectiveSetTest extends \PHPUnit\Framework\TestCase
                     'form-action' => array('form-action.example.org', "'self'"),
                     'frame-ancestors' => array('frame-ancestors.example.org', "'self'"),
                     'plugin-types' => array('application/shockwave-flash'),
+                    'trusted-types' => array('foo'),
+                    'require-trusted-types-for' => array('script'),
                     'block-all-mixed-content' => true,
                     'upgrade-insecure-requests' => true,
                 ),


### PR DESCRIPTION
Linked to issue #233 

This PR extends the current CSP configuration within the Nelmio Security bundle to include the new Trusted-Types policy headers
- `trusted-types: <POLICY NAMES>`
- `require-trusted-types-for: <DOM-SINK>`

These directives interface with the new trusted types feature, with the hopes of reducing DOM based XSS sinks. They instruct user agents to restrict usage of known DOM XSS sinks to a predefined set of functions or Policies. Resources linked at the end of this description describe the spec for trusted types and their Benifits.

- [MDN Trusted Types](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/trusted-types)
- [Prevent DOM-based cross-site scripting vulnerabilities with Trusted Types](https://web.dev/trusted-types/)
- [W3C specifications for Trusted types and headers](https://web.dev/trusted-types/)
