### PR TITLE
Allow installation alongside `paragonie/random_compat` `9.99.100`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     ],
     "require": {
         "php": ">5.4",
-        "paragonie/random_compat": "~1.0|~2.0|9.99.99",
+        "paragonie/random_compat": "~1.0|~2.0|9.99.*",
         "symfony/framework-bundle": "~2.3|~v3.0|~4.0|~5.0",
         "symfony/security-core": "~2.3|~3.0|~4.0|~5.0",
         "symfony/security-http": "~2.3|~3.0|~4.0|~5.0",

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     ],
     "require": {
         "php": ">5.4",
-        "paragonie/random_compat": "~1.0|~2.0|9.99.*",
+        "paragonie/random_compat": "~1.0|~2.0|~9.99.99",
         "symfony/framework-bundle": "~2.3|~v3.0|~4.0|~5.0",
         "symfony/security-core": "~2.3|~3.0|~4.0|~5.0",
         "symfony/security-http": "~2.3|~3.0|~4.0|~5.0",


### PR DESCRIPTION
Hi, 

Apparently `paragonie/random_compat` `9.99.100` was released and now this package can't be installed any longer: 

```bash
$ composer require nelmio/security-bundle
Warning from https://repo.packagist.org: You are using an outdated version of Composer. Composer 2.0 is about to be released and the older 1.x releases will self-update directly to it once it is released. To avoid surprises update now to the latest 1.x version which will prompt you before self-updating to 2.x.
Warning from https://repo.packagist.org: You are using an outdated version of Composer. Composer 2.0 is about to be released and the older 1.x releases will self-update directly to it once it is released. To avoid surprises update now to the latest 1.x version which will prompt you before self-updating to 2.x.
Using version ^2.10 for nelmio/security-bundle
./composer.json has been updated
Loading composer repositories with package information
Warning from https://repo.packagist.org: You are using an outdated version of Composer. Composer 2.0 is about to be released and the older 1.x releases will self-update directly to it once it is released. To avoid surprises update now to the latest 1.x version which will prompt you before self-updating to 2.x.
Updating dependencies (including require-dev)
Restricting packages listed in "symfony/symfony" to "^5.1"
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - nelmio/security-bundle v2.10.0 requires paragonie/random_compat ~1.0|~2.0|9.99.99 -> satisfiable by paragonie/random_compat[1.0.10, 1.0.2, 1.0.3, 1.0.4, 1.0.5, 1.0.6, 1.0.7, 1.0.8, 1.0.9, 1.1.0, 1.1.1, 1.1.2, 1.1.3, 1.1.4, 1.1.5, 1.1.6, v1.0.0, v1.0.1, v1.2.0, v1.2.1, v1.2.2, v1.2.3, v1.3.0, v1.3.1, v1.4.0, v1.4.1, v1.4.2, v1.4.3, v1.x-dev, v2.0.0, v2.0.1, v2.0.10, v2.0.11, v2.0.12, v2.0.13, v2.0.14, v2.0.15, v2.0.16, v2.0.17, v2.0.18, v2.0.19, v2.0.2, v2.0.3, v2.0.4, v2.0.5, v2.0.6, v2.0.7, v2.0.8, v2.0.9, v9.99.99].
    - nelmio/security-bundle v2.10.1 requires paragonie/random_compat ~1.0|~2.0|9.99.99 -> satisfiable by paragonie/random_compat[1.0.10, 1.0.2, 1.0.3, 1.0.4, 1.0.5, 1.0.6, 1.0.7, 1.0.8, 1.0.9, 1.1.0, 1.1.1, 1.1.2, 1.1.3, 1.1.4, 1.1.5, 1.1.6, v1.0.0, v1.0.1, v1.2.0, v1.2.1, v1.2.2, v1.2.3, v1.3.0, v1.3.1, v1.4.0, v1.4.1, v1.4.2, v1.4.3, v1.x-dev, v2.0.0, v2.0.1, v2.0.10, v2.0.11, v2.0.12, v2.0.13, v2.0.14, v2.0.15, v2.0.16, v2.0.17, v2.0.18, v2.0.19, v2.0.2, v2.0.3, v2.0.4, v2.0.5, v2.0.6, v2.0.7, v2.0.8, v2.0.9, v9.99.99].
    - paragonie/random_compat 1.0.10 conflicts with __root__[No version set (parsed as 1.0.0)].
    - paragonie/random_compat 1.0.2 conflicts with __root__[No version set (parsed as 1.0.0)].
    - paragonie/random_compat 1.0.3 conflicts with __root__[No version set (parsed as 1.0.0)].
    - paragonie/random_compat 1.0.4 conflicts with __root__[No version set (parsed as 1.0.0)].
    - paragonie/random_compat 1.0.5 conflicts with __root__[No version set (parsed as 1.0.0)].
    - paragonie/random_compat 1.0.6 conflicts with __root__[No version set (parsed as 1.0.0)].
    - paragonie/random_compat 1.0.7 conflicts with __root__[No version set (parsed as 1.0.0)].
    - paragonie/random_compat 1.0.8 conflicts with __root__[No version set (parsed as 1.0.0)].
    - paragonie/random_compat 1.0.9 conflicts with __root__[No version set (parsed as 1.0.0)].
    - paragonie/random_compat 1.1.0 conflicts with __root__[No version set (parsed as 1.0.0)].
    - paragonie/random_compat 1.1.1 conflicts with __root__[No version set (parsed as 1.0.0)].
    - paragonie/random_compat 1.1.2 conflicts with __root__[No version set (parsed as 1.0.0)].
    - paragonie/random_compat 1.1.3 conflicts with __root__[No version set (parsed as 1.0.0)].
    - paragonie/random_compat 1.1.4 conflicts with __root__[No version set (parsed as 1.0.0)].
    - paragonie/random_compat 1.1.5 conflicts with __root__[No version set (parsed as 1.0.0)].
    - paragonie/random_compat 1.1.6 conflicts with __root__[No version set (parsed as 1.0.0)].
    - paragonie/random_compat v1.0.0 conflicts with __root__[No version set (parsed as 1.0.0)].
    - paragonie/random_compat v1.0.1 conflicts with __root__[No version set (parsed as 1.0.0)].
    - paragonie/random_compat v1.2.0 conflicts with __root__[No version set (parsed as 1.0.0)].
    - paragonie/random_compat v1.2.1 conflicts with __root__[No version set (parsed as 1.0.0)].
    - paragonie/random_compat v1.2.2 conflicts with __root__[No version set (parsed as 1.0.0)].
    - paragonie/random_compat v1.2.3 conflicts with __root__[No version set (parsed as 1.0.0)].
    - paragonie/random_compat v1.3.0 conflicts with __root__[No version set (parsed as 1.0.0)].
    - paragonie/random_compat v1.3.1 conflicts with __root__[No version set (parsed as 1.0.0)].
    - paragonie/random_compat v1.4.0 conflicts with __root__[No version set (parsed as 1.0.0)].
    - paragonie/random_compat v1.4.1 conflicts with __root__[No version set (parsed as 1.0.0)].
    - paragonie/random_compat v1.4.2 conflicts with __root__[No version set (parsed as 1.0.0)].
    - paragonie/random_compat v1.4.3 conflicts with __root__[No version set (parsed as 1.0.0)].
    - paragonie/random_compat v1.x-dev conflicts with __root__[No version set (parsed as 1.0.0)].
    - paragonie/random_compat v2.0.0 conflicts with __root__[No version set (parsed as 1.0.0)].
    - paragonie/random_compat v2.0.1 conflicts with __root__[No version set (parsed as 1.0.0)].
    - paragonie/random_compat v2.0.10 conflicts with __root__[No version set (parsed as 1.0.0)].
    - paragonie/random_compat v2.0.11 conflicts with __root__[No version set (parsed as 1.0.0)].
    - paragonie/random_compat v2.0.12 conflicts with __root__[No version set (parsed as 1.0.0)].
    - paragonie/random_compat v2.0.13 conflicts with __root__[No version set (parsed as 1.0.0)].
    - paragonie/random_compat v2.0.14 conflicts with __root__[No version set (parsed as 1.0.0)].
    - paragonie/random_compat v2.0.15 conflicts with __root__[No version set (parsed as 1.0.0)].
    - paragonie/random_compat v2.0.16 conflicts with __root__[No version set (parsed as 1.0.0)].
    - paragonie/random_compat v2.0.17 conflicts with __root__[No version set (parsed as 1.0.0)].
    - paragonie/random_compat v2.0.18 conflicts with __root__[No version set (parsed as 1.0.0)].
    - paragonie/random_compat v2.0.19 conflicts with __root__[No version set (parsed as 1.0.0)].
    - paragonie/random_compat v2.0.2 conflicts with __root__[No version set (parsed as 1.0.0)].
    - paragonie/random_compat v2.0.3 conflicts with __root__[No version set (parsed as 1.0.0)].
    - paragonie/random_compat v2.0.4 conflicts with __root__[No version set (parsed as 1.0.0)].
    - paragonie/random_compat v2.0.5 conflicts with __root__[No version set (parsed as 1.0.0)].
    - paragonie/random_compat v2.0.6 conflicts with __root__[No version set (parsed as 1.0.0)].
    - paragonie/random_compat v2.0.7 conflicts with __root__[No version set (parsed as 1.0.0)].
    - paragonie/random_compat v2.0.8 conflicts with __root__[No version set (parsed as 1.0.0)].
    - paragonie/random_compat v2.0.9 conflicts with __root__[No version set (parsed as 1.0.0)].
    - paragonie/random_compat v9.99.99 conflicts with __root__[No version set (parsed as 1.0.0)].
    - Installation request for __root__ No version set (parsed as 1.0.0) -> satisfiable by __root__[No version set (parsed as 1.0.0)].
    - Installation request for nelmio/security-bundle ^2.10 -> satisfiable by nelmio/security-bundle[v2.10.0, v2.10.1].


Installation failed, reverting ./composer.json to its original content.
```