### PR TITLE
Add the wasm-unsafe-eval keyword for CSP

### DIFF
--- a/ContentSecurityPolicy/ContentSecurityPolicyParser.php
+++ b/ContentSecurityPolicy/ContentSecurityPolicyParser.php
@@ -17,6 +17,7 @@ class ContentSecurityPolicyParser
         'self',
         'unsafe-inline',
         'unsafe-eval',
+        'wasm-unsafe-eval',
         'strict-dynamic',
         'unsafe-hashes',
         'report-sample',


### PR DESCRIPTION
See https://w3c.github.io/webappsec-csp/#directive-script-src

`wasm-unsafe-eval` is more specific than `unsafe-eval`, by allowing only APIs that can evaluate WebAssembly but not APIs that can evaluate JS (`unsafe-eval` allows both)