### PR TITLE
Added return types annotations

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -30,6 +30,9 @@ class Configuration implements ConfigurationInterface
         '',
     );
 
+    /**
+     * @return TreeBuilder
+     */
     public function getConfigTreeBuilder()
     {
         $treeBuilder = new TreeBuilder('nelmio_security', 'array');

--- a/EventListener/ContentSecurityPolicyListener.php
+++ b/EventListener/ContentSecurityPolicyListener.php
@@ -207,6 +207,9 @@ class ContentSecurityPolicyListener extends AbstractContentTypeRestrictableListe
         return $headers;
     }
 
+    /**
+     * @return array
+     */
     public static function getSubscribedEvents()
     {
         return array(

--- a/Twig/NelmioCSPTwigExtension.php
+++ b/Twig/NelmioCSPTwigExtension.php
@@ -29,6 +29,9 @@ class NelmioCSPTwigExtension extends AbstractExtension
         $this->shaComputer = $shaComputer;
     }
 
+    /**
+     * @return array
+     */
     public function getTokenParsers()
     {
         return array(new CSPScriptParser($this->shaComputer), new CSPStyleParser($this->shaComputer));
@@ -44,6 +47,9 @@ class NelmioCSPTwigExtension extends AbstractExtension
         return 'Nelmio\\SecurityBundle\\Twig\\NelmioCSPTwigExtension';
     }
 
+    /**
+     * @return array
+     */
     public function getFunctions()
     {
         return array(


### PR DESCRIPTION
Suppressed these messages:

> Method "Symfony\Component\Config\Definition\ConfigurationInterface::getConfigTreeBuilder()" might add "TreeBuilder" as a native return type declaration in the future. Do the same in implementation "Nelmio\SecurityBundle\DependencyInjection\Configuration" now to avoid errors or add an explicit @return annotation to suppress this message.

> Method "Symfony\Component\EventDispatcher\EventSubscriberInterface::getSubscribedEvents()" might add "array" as a native return type declaration in the future. Do the same in implementation "Nelmio\SecurityBundle\EventListener\ContentSecurityPolicyListener" now to avoid errors or add an explicit @return annotation to suppress this message.

> User Deprecated: Method "Twig\Extension\ExtensionInterface::getTokenParsers()" might add "array" as a native return type declaration in the future. Do the same in implementation "Nelmio\SecurityBundle\Twig\NelmioCSPTwigExtension" now to avoid errors or add an explicit @return annotation to suppress this message.

> User Deprecated: Method "Twig\Extension\ExtensionInterface::getFunctions()" might add "array" as a native return type declaration in the future. Do the same in implementation "Nelmio\SecurityBundle\Twig\NelmioCSPTwigExtension" now to avoid errors or add an explicit @return annotation to suppress this message.
