### PR TITLE
Various CSP reporting improvements

### DIFF
--- a/ContentSecurityPolicy/Violation/Filter/BrowserBugsNoiseDetector.php
+++ b/ContentSecurityPolicy/Violation/Filter/BrowserBugsNoiseDetector.php
@@ -36,6 +36,11 @@ class BrowserBugsNoiseDetector implements NoiseDetectorInterface
                 }
             }
         }
+        
+        // https://bugzilla.mozilla.org/show_bug.cgi?id=1445643
+        if ($report->getUri() === 'moz-extension') {
+            return true;
+        }
 
         // https://bugzilla.mozilla.org/show_bug.cgi?id=1263286
         if ($report->getDirective() === 'base-uri' && in_array($report->getUri(), array('about:blank', 'about'), true)) {
@@ -48,9 +53,12 @@ class BrowserBugsNoiseDetector implements NoiseDetectorInterface
             }
         }
 
-        // files loaded by safari extension
+        // files loaded by safari & firefox extension
         // should be allowed as in Chrome
-        if (($sourceFile = $report->getSourceFile()) !== null && 0 === strpos($sourceFile, 'safari-extension://')) {
+        if (
+            ($sourceFile = $report->getSourceFile()) !== null
+            && (0 === strpos($sourceFile, 'safari-extension://') || 'moz-extension' === $sourceFile)
+        ) {
             return true;
         }
 

--- a/ContentSecurityPolicy/Violation/Log/Logger.php
+++ b/ContentSecurityPolicy/Violation/Log/Logger.php
@@ -20,7 +20,7 @@ class Logger
 
     public function log(Report $report)
     {
-        $this->logger->log($this->level, $this->logFormatter->format($report), array('csp-report' => $report->getData()));
+        $this->logger->log($this->level, $this->logFormatter->format($report), array('csp-report' => $report->getData(), 'user-agent' => $report->getUserAgent()));
     }
 
     public function getLogger()

--- a/ContentSecurityPolicy/Violation/Report.php
+++ b/ContentSecurityPolicy/Violation/Report.php
@@ -19,10 +19,12 @@ use Nelmio\SecurityBundle\ContentSecurityPolicy\Violation\Exception\NoDataExcept
 class Report
 {
     private $data;
+    private $userAgent;
 
-    public function __construct(array $data = array())
+    public function __construct(array $data = array(), $userAgent = null)
     {
         $this->data = $data;
+        $this->userAgent = $userAgent;
     }
 
     public function setProperty($key, $value)
@@ -103,6 +105,11 @@ class Report
     {
         return $this->data;
     }
+    
+    public function getUserAgent()
+    {
+        return $this->userAgent;
+    }
 
     public static function fromRequest(Request $request)
     {
@@ -146,6 +153,6 @@ class Report
             $ret['script-sample'] = $report['csp-report']['script-sample'];
         }
 
-        return new self($report);
+        return new self($report, $request->headers->get('User-Agent'));
     }
 }


### PR DESCRIPTION
- Filter moz-extension reports as they all look bogus
- Log user agent as well as CSP report data when logging CSP violations, which may help identify buggy browser patterns