### PR TITLE
Bump PHPStan to level 7

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,0 +1,22 @@
+parameters:
+	ignoreErrors:
+		-
+			message: "#^Method Nelmio\\\\SecurityBundle\\\\ContentSecurityPolicy\\\\DirectiveSet\\:\\:normalizeSignatures\\(\\) should return array\\<string, string\\>\\|null but returns array\\<string, array\\<int, string\\>\\|string\\>\\.$#"
+			count: 1
+			path: src/ContentSecurityPolicy/DirectiveSet.php
+
+		-
+			message: "#^Offset 'enforce'\\|'report' does not exist on array\\{enforce\\?\\: array\\{browser_adaptive\\: array\\{enabled\\: bool, parser\\: string\\}\\}, report\\?\\: array\\{browser_adaptive\\: array\\{enabled\\: bool, parser\\: string\\}\\}\\}\\.$#"
+			count: 1
+			path: src/DependencyInjection/NelmioSecurityExtension.php
+
+		-
+			message: "#^Parameter \\#1 \\$name of class Symfony\\\\Component\\\\HttpFoundation\\\\Cookie constructor expects string, string\\|false given\\.$#"
+			count: 1
+			path: src/EventListener/FlexibleSslListener.php
+
+		-
+			message: "#^Parameter \\#2 \\$value of class Symfony\\\\Component\\\\HttpFoundation\\\\Cookie constructor expects string\\|null, string\\|false given\\.$#"
+			count: 1
+			path: src/EventListener/FlexibleSslListener.php
+

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,10 +1,11 @@
 includes:
+    - phpstan-baseline.neon
     - vendor/phpstan/phpstan-phpunit/extension.neon
     - vendor/phpstan/phpstan-symfony/extension.neon
     - vendor/phpstan/phpstan-strict-rules/rules.neon
 
 parameters:
-    level: 6
+    level: 7
     paths:
         - src
         - tests

--- a/src/ContentSecurityPolicy/DirectiveSet.php
+++ b/src/ContentSecurityPolicy/DirectiveSet.php
@@ -117,12 +117,7 @@ class DirectiveSet
     {
         $policy = [];
 
-        if (isset($signatures['script-src'])) {
-            $signatures['script-src'] = implode(' ', array_map(function ($value) { return sprintf('\'%s\'', $value); }, $signatures['script-src']));
-        }
-        if (isset($signatures['style-src'])) {
-            $signatures['style-src'] = implode(' ', array_map(function ($value) { return sprintf('\'%s\'', $value); }, $signatures['style-src']));
-        }
+        $signatures = $this->normalizeSignatures($signatures);
 
         $availableDirectives = $this->policyManager->getAvailableDirective($request);
 
@@ -149,7 +144,7 @@ class DirectiveSet
 
         if (null !== $signatures && [] !== $signatures) {
             $defaultSrc = $this->getDirective('default-src');
-            $isDefaultSrcSet = '' !== $defaultSrc;
+            $isDefaultSrcSet = '' !== $defaultSrc && true !== $defaultSrc;
 
             if ($isDefaultSrcSet && false === strpos($defaultSrc, '\'unsafe-inline\'')) {
                 $unsafeInline = $this->level1Fallback ? ' \'unsafe-inline\'' : '';
@@ -219,5 +214,39 @@ class DirectiveSet
 
         // let's fallback if directives are strictly equals
         return $value !== $this->getDirective('default-src');
+    }
+
+    /**
+     * @param array<string, list<string>>|null $signatures
+     *
+     * @return array<string, string>|null
+     */
+    private function normalizeSignatures(?array $signatures): ?array
+    {
+        if (null === $signatures) {
+            return null;
+        }
+
+        $normalizedSignatures = $signatures;
+
+        if (isset($signatures['script-src'])) {
+            $normalizedSignatures['script-src'] = implode(
+                ' ',
+                array_map(static function (string $value): string {
+                    return sprintf('\'%s\'', $value);
+                }, $signatures['script-src'])
+            );
+        }
+
+        if (isset($signatures['style-src'])) {
+            $normalizedSignatures['style-src'] = implode(
+                ' ',
+                array_map(static function (string $value): string {
+                    return sprintf('\'%s\'', $value);
+                }, $signatures['style-src'])
+            );
+        }
+
+        return $normalizedSignatures;
     }
 }

--- a/src/ContentSecurityPolicy/ShaComputer.php
+++ b/src/ContentSecurityPolicy/ShaComputer.php
@@ -76,11 +76,22 @@ class ShaComputer
 
     private function compute(string $data): string
     {
+        return sprintf('%s-%s', $this->type, base64_encode($this->computeHash($data)));
+    }
+
+    private function computeHash(string $data): string
+    {
         switch ($this->getFavorite()) {
             case 'openssl':
-                return sprintf('%s-%s', $this->type, base64_encode(openssl_digest($data, $this->type, true)));
+                $hash = openssl_digest($data, $this->type, true);
+
+                if (false === $hash) {
+                    throw new \RuntimeException('Failed executing "openssl_digest".');
+                }
+
+                return $hash;
             case 'hash':
-                return sprintf('%s-%s', $this->type, base64_encode(hash($this->type, $data, true)));
+                return hash($this->type, $data, true);
         }
 
         throw new \RuntimeException('No hash function on this platform');

--- a/src/DependencyInjection/Compiler/UAParserCompilerPass.php
+++ b/src/DependencyInjection/Compiler/UAParserCompilerPass.php
@@ -25,8 +25,12 @@ class UAParserCompilerPass implements CompilerPassInterface
             return;
         }
 
+        $browserAdaptativeParser = $container->getParameter('nelmio_browser_adaptive_parser');
+
+        assert(is_string($browserAdaptativeParser));
+
         $container
             ->getDefinition('nelmio_security.ua_parser')
-            ->setArguments([new Reference($container->getParameter('nelmio_browser_adaptive_parser'))]);
+            ->setArguments([new Reference($browserAdaptativeParser)]);
     }
 }

--- a/src/DependencyInjection/NelmioSecurityExtension.php
+++ b/src/DependencyInjection/NelmioSecurityExtension.php
@@ -185,6 +185,7 @@ class NelmioSecurityExtension extends Extension
      *      }
      *  }
      * } $config
+     * @phpstan-param 'enforce'|'report' $type
      */
     private function buildDirectiveSetDefinition(ContainerBuilder $container, array $config, string $type): Definition
     {

--- a/src/ExternalRedirect/WhitelistBasedTargetValidator.php
+++ b/src/ExternalRedirect/WhitelistBasedTargetValidator.php
@@ -16,7 +16,7 @@ namespace Nelmio\SecurityBundle\ExternalRedirect;
 class WhitelistBasedTargetValidator implements TargetValidator
 {
     /**
-     * @var string[]|string|null
+     * @var string|null
      */
     private $whitelist;
 
@@ -44,6 +44,12 @@ class WhitelistBasedTargetValidator implements TargetValidator
             return false;
         }
 
-        return preg_match('{^'.$this->whitelist.'$}i', parse_url($targetUrl, PHP_URL_HOST)) > 0;
+        $host = parse_url($targetUrl, PHP_URL_HOST);
+
+        if (!is_string($host)) {
+            throw new \InvalidArgumentException(sprintf('Url "%s" does not contain a host name.', $targetUrl));
+        }
+
+        return preg_match('{^'.$this->whitelist.'$}i', $host) > 0;
     }
 }

--- a/tests/Functional/ContentSecurityPolicyTest.php
+++ b/tests/Functional/ContentSecurityPolicyTest.php
@@ -66,9 +66,7 @@ final class ContentSecurityPolicyTest extends WebTestCase
     {
         $client = static::createClient();
 
-        $client->request('POST', '/csp/report', [], [], [], json_encode(['csp-report' => [
-            'blocked-uri' => 'translate.google.com',
-        ]]));
+        $client->request('POST', '/csp/report', [], [], [], '{"csp-report":{"blocked-uri":"translate.google.com"}}');
 
         $this->assertResponseStatusCodeSame(204);
         $this->assertSame('', $client->getResponse()->getContent());
@@ -78,7 +76,7 @@ final class ContentSecurityPolicyTest extends WebTestCase
     {
         $client = static::createClient();
 
-        $client->request('POST', '/csp/report', [], [], [], json_encode(['csp-report' => []]));
+        $client->request('POST', '/csp/report', [], [], [], '{"csp-report":[]}');
 
         $this->assertResponseStatusCodeSame(204);
         $this->assertSame('', $client->getResponse()->getContent());

--- a/tests/Listener/ContentSecurityPolicyListenerTest.php
+++ b/tests/Listener/ContentSecurityPolicyListenerTest.php
@@ -278,6 +278,7 @@ class ContentSecurityPolicyListenerTest extends TestCase
 
         $header = $response->headers->get('Content-Security-Policy');
 
+        $this->assertIsString($header);
         $this->assertStringContainsString("default-src example.org 'self'", $header, 'Header should contain default-src');
         $this->assertStringContainsString("script-src script.example.org 'self'", $header, 'Header should contain script-src');
         $this->assertStringContainsString("object-src object.example.org 'self'", $header, 'Header should contain object-src');

--- a/tests/Listener/FlexibleSslListenerTest.php
+++ b/tests/Listener/FlexibleSslListenerTest.php
@@ -128,7 +128,6 @@ class FlexibleSslListenerTest extends TestCase
         $this->listener->onPostLoginKernelResponse($event);
 
         $cookies = $response->headers->getCookies(ResponseHeaderBag::COOKIES_ARRAY);
-        $this->assertInstanceOf(Cookie::class, $cookies['']['/']['unsecure']);
         $this->assertTrue(isset($cookies['']['/']['unsecure']));
         $this->assertSame('unsecure_value', $cookies['']['/']['unsecure']->getValue());
         $this->assertTrue($cookies['']['/']['unsecure']->isSecure());

--- a/tests/Listener/ForcedSslListenerTest.php
+++ b/tests/Listener/ForcedSslListenerTest.php
@@ -76,6 +76,7 @@ class ForcedSslListenerTest extends TestCase
         $this->assertNull($response);
 
         $response = $this->callListenerReq($listener, 'http://localhost/lala/foo/lala', true);
+        $this->assertInstanceOf(Response::class, $response);
         $this->assertSame('https://localhost/lala/foo/lala', $response->headers->get('Location'));
 
         $response = $this->callListenerReq($listener, 'https://localhost/lala/abarb', true);
@@ -90,9 +91,11 @@ class ForcedSslListenerTest extends TestCase
         $this->assertNull($response);
 
         $response = $this->callListenerReq($listener, 'http://foo.com/foo/lala', true);
+        $this->assertInstanceOf(Response::class, $response);
         $this->assertSame('https://foo.com/foo/lala', $response->headers->get('Location'));
 
         $response = $this->callListenerReq($listener, 'http://test.example.org/foo/lala', true);
+        $this->assertInstanceOf(Response::class, $response);
         $this->assertSame('https://test.example.org/foo/lala', $response->headers->get('Location'));
     }
 
@@ -101,11 +104,13 @@ class ForcedSslListenerTest extends TestCase
         $listener = new ForcedSslListener(null, false);
 
         $response = $this->callListenerReq($listener, '/foo/lala', true);
+        $this->assertInstanceOf(Response::class, $response);
         $this->assertSame(302, $response->getStatusCode());
 
         $listener = new ForcedSslListener(null, false, false, [], [], 301);
 
         $response = $this->callListenerReq($listener, '/foo/lala', true);
+        $this->assertInstanceOf(Response::class, $response);
         $this->assertSame(301, $response->getStatusCode());
     }
 


### PR DESCRIPTION
The ignored errors are because:
- `session_id()` and `session_name()` returning `string|false`.
- one related with https://github.com/phpstan/phpstan/discussions/6507
- The other one I'm not sure if in the signatures can be all the directives to be able to specify the array shape, I prefer to ignore it for now

After this there will be 14 errors left in level 8.