### PR TITLE
Bump PHPStan level to 8

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -20,3 +20,7 @@ parameters:
 			count: 1
 			path: src/EventListener/FlexibleSslListener.php
 
+		-
+			message: "#^Parameter \\#1 \\$value of method Nelmio\\\\SecurityBundle\\\\Signer\\:\\:getSignedValue\\(\\) expects string, string\\|null given\\.$#"
+			count: 1
+			path: src/EventListener/SignedCookieListener.php

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -5,7 +5,7 @@ includes:
     - vendor/phpstan/phpstan-strict-rules/rules.neon
 
 parameters:
-    level: 7
+    level: 8
     paths:
         - src
         - tests

--- a/src/ContentSecurityPolicy/PolicyManager.php
+++ b/src/ContentSecurityPolicy/PolicyManager.php
@@ -36,7 +36,13 @@ class PolicyManager
             return $this->getChromeDirectives();
         }
 
-        switch ($this->uaParser->getBrowser($request->headers->get('user-agent'))) {
+        $userAgent = $request->headers->get('user-agent');
+
+        if (null === $userAgent) {
+            return [];
+        }
+
+        switch ($this->uaParser->getBrowser($userAgent)) {
             case UserAgentParserInterface::BROWSER_CHROME:
             case UserAgentParserInterface::BROWSER_OPERA:
             case UserAgentParserInterface::BROWSER_OTHER:

--- a/src/ContentSecurityPolicy/Violation/Filter/CustomRulesNoiseDetector.php
+++ b/src/ContentSecurityPolicy/Violation/Filter/CustomRulesNoiseDetector.php
@@ -46,7 +46,7 @@ class CustomRulesNoiseDetector implements NoiseDetectorInterface
             }
 
             if ('/' === $pattern[0]) {
-                if (1 === preg_match($pattern, $uri)) {
+                if (null !== $uri && 1 === preg_match($pattern, $uri)) {
                     return true;
                 }
             } elseif ($pattern === $domain) {

--- a/src/DependencyInjection/NelmioSecurityExtension.php
+++ b/src/DependencyInjection/NelmioSecurityExtension.php
@@ -111,7 +111,7 @@ class NelmioSecurityExtension extends Extension
             $container->setParameter('nelmio_security.external_redirects.forward_as', $config['external_redirects']['forward_as']);
             $container->setParameter('nelmio_security.external_redirects.abort', $config['external_redirects']['abort']);
             if ($config['external_redirects']['whitelist']) {
-                $whitelist = array_map(static function ($el) {
+                $whitelist = array_map(static function (string $el): string {
                     $host = parse_url($el, PHP_URL_HOST);
                     if (is_string($host)) {
                         return ltrim($host, '.');

--- a/src/EventListener/AbstractContentTypeRestrictableListener.php
+++ b/src/EventListener/AbstractContentTypeRestrictableListener.php
@@ -37,6 +37,10 @@ abstract class AbstractContentTypeRestrictableListener implements EventSubscribe
             return true;
         }
 
+        if (null === $response->headers->get('content-type')) {
+            return false;
+        }
+
         $contentTypeData = explode(';', $response->headers->get('content-type'), 2);
 
         return in_array(trim($contentTypeData[0]), $this->contentTypes, true);

--- a/src/EventListener/ExternalRedirectListener.php
+++ b/src/EventListener/ExternalRedirectListener.php
@@ -84,6 +84,11 @@ class ExternalRedirectListener
         }
 
         $target = $response->headers->get('Location');
+
+        if (null === $target) {
+            return;
+        }
+
         if (!$this->isExternalRedirect($e->getRequest()->getUri(), $target)) {
             return;
         }

--- a/src/EventListener/FlexibleSslListener.php
+++ b/src/EventListener/FlexibleSslListener.php
@@ -120,7 +120,13 @@ class FlexibleSslListener implements BaseFlexibleSslListener
 
     public function onLogout(LogoutEvent $e): void
     {
-        $this->logout($e->getRequest(), $e->getResponse(), $e->getToken());
+        $response = $e->getResponse();
+
+        if (null === $response) {
+            return;
+        }
+
+        $this->doLogout($response);
     }
 
     /**
@@ -128,7 +134,12 @@ class FlexibleSslListener implements BaseFlexibleSslListener
      */
     public function logout(Request $request, Response $response, TokenInterface $token): void
     {
-        if ($this->unsecuredLogout) {
+        $this->doLogout($response);
+    }
+
+    private function doLogout(Response $response): void
+    {
+        if ($this->unsecuredLogout && null !== $response->headers->get('Location')) {
             $location = $response->headers->get('Location');
             $response->headers->set('Location', preg_replace('/^https/', 'http', $location));
         }

--- a/src/ExternalRedirect/WhitelistBasedTargetValidator.php
+++ b/src/ExternalRedirect/WhitelistBasedTargetValidator.php
@@ -27,7 +27,7 @@ class WhitelistBasedTargetValidator implements TargetValidator
     {
         if (is_array($whitelist)) {
             if ([] !== $whitelist) {
-                $whitelist = array_map(function ($el) {
+                $whitelist = array_map(static function (string $el): string {
                     return preg_quote(ltrim($el, '.'));
                 }, $whitelist);
                 $whitelist = '(?:.*\.'.implode('|.*\.', $whitelist).'|'.implode('|', $whitelist).')';

--- a/src/Session/CookieSessionHandler.php
+++ b/src/Session/CookieSessionHandler.php
@@ -66,6 +66,8 @@ class CookieSessionHandler implements \SessionHandlerInterface
             $this->logger->debug('CookieSessionHandler::onKernelResponse - Get the Response object');
         }
 
+        assert(null !== $this->request);
+
         $this->request->getSession()->save();
 
         if (false === $this->cookie) {

--- a/tests/Listener/FlexibleSslListenerTest.php
+++ b/tests/Listener/FlexibleSslListenerTest.php
@@ -66,6 +66,7 @@ class FlexibleSslListenerTest extends TestCase
         $this->listener->onKernelRequest($event);
 
         $this->assertTrue($event->hasResponse());
+        $this->assertInstanceOf(Response::class, $event->getResponse());
         $this->assertTrue($event->getResponse()->isRedirection());
     }
 


### PR DESCRIPTION
With level 8 I think we are fine with the static analysis.

The ignored errors added are about `InputBag::get()` call returning `null` after calling `:InputBag:has()`, issue related to https://github.com/phpstan/phpstan-symfony/pull/250.