### PR TITLE
Add PHPStan deprecation rules

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,7 @@
     },
     "require-dev": {
         "phpstan/phpstan": "^1.4",
+        "phpstan/phpstan-deprecation-rules": "^1.0",
         "phpstan/phpstan-phpunit": "^1.0",
         "phpstan/phpstan-strict-rules": "^1.1",
         "phpstan/phpstan-symfony": "^1.1",

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -24,3 +24,13 @@ parameters:
 			message: "#^Parameter \\#1 \\$value of method Nelmio\\\\SecurityBundle\\\\Signer\\:\\:getSignedValue\\(\\) expects string, string\\|null given\\.$#"
 			count: 1
 			path: src/EventListener/SignedCookieListener.php
+
+		-
+			message: """
+				#^Fetching deprecated class constant MASTER_REQUEST of class Symfony\\\\Component\\\\HttpKernel\\\\HttpKernelInterface\\:
+				since symfony/http\\-kernel 5\\.3, use MAIN_REQUEST instead\\.
+				            To ease the migration, this constant won't be removed until Symfony 7\\.0\\.$#
+			"""
+			count: 1
+			path: tests/Listener/ListenerTestCase.php
+

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,8 +1,9 @@
 includes:
     - phpstan-baseline.neon
+    - vendor/phpstan/phpstan-deprecation-rules/rules.neon
     - vendor/phpstan/phpstan-phpunit/extension.neon
-    - vendor/phpstan/phpstan-symfony/extension.neon
     - vendor/phpstan/phpstan-strict-rules/rules.neon
+    - vendor/phpstan/phpstan-symfony/extension.neon
 
 parameters:
     level: 8
@@ -15,6 +16,9 @@ parameters:
     ignoreErrors:
         - '#^Dynamic call to static method PHPUnit\\Framework\\\S+\(\)\.$#'
         - '#^Dynamic call to static method Symfony\\Bundle\\FrameworkBundle\\Test\\\S+\(\)\.$#'
+        # BC with Symfony 4.4
+        - "#^Call to function method_exists\\(\\) with Symfony\\\\Component\\\\HttpKernel\\\\Event\\\\KernelEvent and 'isMainRequest' will always evaluate to true\\.#"
+        - '#^Call to an undefined method Symfony\\Component\\HttpKernel\\Event\\KernelEvent\:\:isMasterRequest\(\)\.#'
         # Ignore typing providers in tests
         - '#^Method Nelmio\\SecurityBundle\\Tests\\[^:]+Test::(provide\w+|\w+Provider)\(\) return type has no value type specified in iterable type (array|iterable)\.#'
     dynamicConstantNames:

--- a/src/EventListener/ClickjackingListener.php
+++ b/src/EventListener/ClickjackingListener.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace Nelmio\SecurityBundle\EventListener;
 
 use Symfony\Component\HttpKernel\Event\ResponseEvent;
-use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpKernel\KernelEvents;
 
 /**
@@ -22,6 +21,8 @@ use Symfony\Component\HttpKernel\KernelEvents;
  */
 class ClickjackingListener extends AbstractContentTypeRestrictableListener
 {
+    use KernelEventForwardCompatibilityTrait;
+
     /**
      * @var array<string, array<string, string>>
      */
@@ -44,7 +45,7 @@ class ClickjackingListener extends AbstractContentTypeRestrictableListener
 
     public function onKernelResponse(ResponseEvent $e): void
     {
-        if (HttpKernelInterface::MASTER_REQUEST !== $e->getRequestType()) {
+        if (!$this->isMainRequest($e)) {
             return;
         }
 

--- a/src/EventListener/ContentSecurityPolicyListener.php
+++ b/src/EventListener/ContentSecurityPolicyListener.php
@@ -19,7 +19,6 @@ use Nelmio\SecurityBundle\ContentSecurityPolicy\ShaComputer;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\Event\ResponseEvent;
-use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpKernel\KernelEvents;
 
 /**
@@ -27,6 +26,8 @@ use Symfony\Component\HttpKernel\KernelEvents;
  */
 class ContentSecurityPolicyListener extends AbstractContentTypeRestrictableListener
 {
+    use KernelEventForwardCompatibilityTrait;
+
     private DirectiveSet $report;
     private DirectiveSet $enforce;
     private bool $compatHeaders;
@@ -70,7 +71,7 @@ class ContentSecurityPolicyListener extends AbstractContentTypeRestrictableListe
 
     public function onKernelRequest(RequestEvent $e): void
     {
-        if (HttpKernelInterface::MASTER_REQUEST !== $e->getRequestType()) {
+        if (!$this->isMainRequest($e)) {
             return;
         }
 
@@ -146,7 +147,7 @@ class ContentSecurityPolicyListener extends AbstractContentTypeRestrictableListe
 
     public function onKernelResponse(ResponseEvent $e): void
     {
-        if (HttpKernelInterface::MASTER_REQUEST !== $e->getRequestType()) {
+        if (!$this->isMainRequest($e)) {
             return;
         }
 

--- a/src/EventListener/ContentTypeListener.php
+++ b/src/EventListener/ContentTypeListener.php
@@ -14,13 +14,14 @@ declare(strict_types=1);
 namespace Nelmio\SecurityBundle\EventListener;
 
 use Symfony\Component\HttpKernel\Event\ResponseEvent;
-use Symfony\Component\HttpKernel\HttpKernelInterface;
 
 /**
  * @final
  */
 class ContentTypeListener
 {
+    use KernelEventForwardCompatibilityTrait;
+
     private bool $nosniff;
 
     public function __construct(bool $nosniff)
@@ -30,7 +31,7 @@ class ContentTypeListener
 
     public function onKernelResponse(ResponseEvent $e): void
     {
-        if (HttpKernelInterface::MASTER_REQUEST !== $e->getRequestType()) {
+        if (!$this->isMainRequest($e)) {
             return;
         }
 

--- a/src/EventListener/ExternalRedirectListener.php
+++ b/src/EventListener/ExternalRedirectListener.php
@@ -18,7 +18,6 @@ use Nelmio\SecurityBundle\ExternalRedirect\WhitelistBasedTargetValidator;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Symfony\Component\HttpKernel\Exception\HttpException;
-use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 /**
@@ -26,6 +25,8 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
  */
 class ExternalRedirectListener
 {
+    use KernelEventForwardCompatibilityTrait;
+
     private bool $abort;
     private ?string $override;
     private ?string $forwardAs;
@@ -73,7 +74,7 @@ class ExternalRedirectListener
 
     public function onKernelResponse(ResponseEvent $e): void
     {
-        if (HttpKernelInterface::MASTER_REQUEST !== $e->getRequestType()) {
+        if (!$this->isMainRequest($e)) {
             return;
         }
 

--- a/src/EventListener/FlexibleSslListener.php
+++ b/src/EventListener/FlexibleSslListener.php
@@ -20,7 +20,6 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\Event\ResponseEvent;
-use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Http\Event\InteractiveLoginEvent;
 use Symfony\Component\Security\Http\Event\LogoutEvent;
@@ -30,6 +29,8 @@ use Symfony\Component\Security\Http\Event\LogoutEvent;
  */
 class FlexibleSslListener implements BaseFlexibleSslListener
 {
+    use KernelEventForwardCompatibilityTrait;
+
     private string $cookieName;
     private bool $unsecuredLogout;
     private EventDispatcherInterface $dispatcher;
@@ -43,7 +44,7 @@ class FlexibleSslListener implements BaseFlexibleSslListener
 
     public function onKernelRequest(RequestEvent $e): void
     {
-        if (HttpKernelInterface::MASTER_REQUEST !== $e->getRequestType()) {
+        if (!$this->isMainRequest($e)) {
             return;
         }
 
@@ -62,7 +63,7 @@ class FlexibleSslListener implements BaseFlexibleSslListener
 
     public function onPostLoginKernelResponse(ResponseEvent $e): void
     {
-        if (HttpKernelInterface::MASTER_REQUEST !== $e->getRequestType()) {
+        if (!$this->isMainRequest($e)) {
             return;
         }
 

--- a/src/EventListener/ForcedSslListener.php
+++ b/src/EventListener/ForcedSslListener.php
@@ -16,13 +16,14 @@ namespace Nelmio\SecurityBundle\EventListener;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\Event\ResponseEvent;
-use Symfony\Component\HttpKernel\HttpKernelInterface;
 
 /**
  * @final
  */
 class ForcedSslListener
 {
+    use KernelEventForwardCompatibilityTrait;
+
     private ?int $hstsMaxAge;
     private bool $hstsSubdomains;
     private bool $hstsPreload;
@@ -52,7 +53,7 @@ class ForcedSslListener
 
     public function onKernelRequest(RequestEvent $e): void
     {
-        if (HttpKernelInterface::MASTER_REQUEST !== $e->getRequestType()) {
+        if (!$this->isMainRequest($e)) {
             return;
         }
 
@@ -79,7 +80,7 @@ class ForcedSslListener
 
     public function onKernelResponse(ResponseEvent $e): void
     {
-        if (HttpKernelInterface::MASTER_REQUEST !== $e->getRequestType()) {
+        if (!$this->isMainRequest($e)) {
             return;
         }
 

--- a/src/EventListener/KernelEventForwardCompatibilityTrait.php
+++ b/src/EventListener/KernelEventForwardCompatibilityTrait.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Nelmio SecurityBundle.
+ *
+ * (c) Nelmio <hello@nelm.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\SecurityBundle\EventListener;
+
+use Symfony\Component\HttpKernel\Event\KernelEvent;
+
+/**
+ * Provides forward compatibility with newer Symfony versions.
+ *
+ * @internal
+ */
+trait KernelEventForwardCompatibilityTrait
+{
+    protected function isMainRequest(KernelEvent $event): bool
+    {
+        return method_exists($event, 'isMainRequest')
+            ? $event->isMainRequest()
+            : $event->isMasterRequest()
+            ;
+    }
+}

--- a/src/EventListener/ReferrerPolicyListener.php
+++ b/src/EventListener/ReferrerPolicyListener.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace Nelmio\SecurityBundle\EventListener;
 
 use Symfony\Component\HttpKernel\Event\ResponseEvent;
-use Symfony\Component\HttpKernel\HttpKernelInterface;
 
 /**
  * Referrer Policy Listener.
@@ -24,6 +23,8 @@ use Symfony\Component\HttpKernel\HttpKernelInterface;
  */
 class ReferrerPolicyListener
 {
+    use KernelEventForwardCompatibilityTrait;
+
     /**
      * @var list<string>
      */
@@ -39,7 +40,7 @@ class ReferrerPolicyListener
 
     public function onKernelResponse(ResponseEvent $e): void
     {
-        if (HttpKernelInterface::MASTER_REQUEST !== $e->getRequestType()) {
+        if (!$this->isMainRequest($e)) {
             return;
         }
 

--- a/src/EventListener/SignedCookieListener.php
+++ b/src/EventListener/SignedCookieListener.php
@@ -17,13 +17,14 @@ use Nelmio\SecurityBundle\Signer;
 use Symfony\Component\HttpFoundation\Cookie;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\Event\ResponseEvent;
-use Symfony\Component\HttpKernel\HttpKernelInterface;
 
 /**
  * @final
  */
 class SignedCookieListener
 {
+    use KernelEventForwardCompatibilityTrait;
+
     private Signer $signer;
 
     /**
@@ -46,7 +47,7 @@ class SignedCookieListener
 
     public function onKernelRequest(RequestEvent $e): void
     {
-        if (HttpKernelInterface::MASTER_REQUEST !== $e->getRequestType()) {
+        if (!$this->isMainRequest($e)) {
             return;
         }
 
@@ -67,7 +68,7 @@ class SignedCookieListener
 
     public function onKernelResponse(ResponseEvent $e): void
     {
-        if (HttpKernelInterface::MASTER_REQUEST !== $e->getRequestType()) {
+        if (!$this->isMainRequest($e)) {
             return;
         }
 

--- a/src/EventListener/XssProtectionListener.php
+++ b/src/EventListener/XssProtectionListener.php
@@ -15,7 +15,6 @@ namespace Nelmio\SecurityBundle\EventListener;
 
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\Event\ResponseEvent;
-use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpKernel\KernelEvents;
 
 /**
@@ -23,6 +22,8 @@ use Symfony\Component\HttpKernel\KernelEvents;
  */
 class XssProtectionListener implements EventSubscriberInterface
 {
+    use KernelEventForwardCompatibilityTrait;
+
     private bool $enabled;
     private bool $modeBlock;
     private ?string $reportUri;
@@ -36,7 +37,7 @@ class XssProtectionListener implements EventSubscriberInterface
 
     public function onKernelResponse(ResponseEvent $e): void
     {
-        if (HttpKernelInterface::MASTER_REQUEST !== $e->getRequestType()) {
+        if (!$this->isMainRequest($e)) {
             return;
         }
 

--- a/src/Session/CookieSessionHandler.php
+++ b/src/Session/CookieSessionHandler.php
@@ -13,18 +13,20 @@ declare(strict_types=1);
 
 namespace Nelmio\SecurityBundle\Session;
 
+use Nelmio\SecurityBundle\EventListener\KernelEventForwardCompatibilityTrait;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpFoundation\Cookie;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\Event\ResponseEvent;
-use Symfony\Component\HttpKernel\HttpKernelInterface;
 
 /**
  * @final
  */
 class CookieSessionHandler implements \SessionHandlerInterface
 {
+    use KernelEventForwardCompatibilityTrait;
+
     private ?Request $request = null;
     private string $cookieName;
     private int $lifetime;
@@ -58,7 +60,7 @@ class CookieSessionHandler implements \SessionHandlerInterface
 
     public function onKernelResponse(ResponseEvent $e): void
     {
-        if (HttpKernelInterface::MASTER_REQUEST !== $e->getRequestType()) {
+        if (!$this->isMainRequest($e)) {
             return;
         }
 
@@ -90,7 +92,7 @@ class CookieSessionHandler implements \SessionHandlerInterface
 
     public function onKernelRequest(RequestEvent $e): void
     {
-        if (HttpKernelInterface::MASTER_REQUEST !== $e->getRequestType()) {
+        if (!$this->isMainRequest($e)) {
             return;
         }
 

--- a/tests/Listener/ClickjackingListenerTest.php
+++ b/tests/Listener/ClickjackingListenerTest.php
@@ -14,14 +14,11 @@ declare(strict_types=1);
 namespace Nelmio\SecurityBundle\Tests\Listener;
 
 use Nelmio\SecurityBundle\EventListener\ClickjackingListener;
-use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpKernel\Event\ResponseEvent;
-use Symfony\Component\HttpKernel\HttpKernelInterface;
 
-class ClickjackingListenerTest extends TestCase
+class ClickjackingListenerTest extends ListenerTestCase
 {
     private ClickjackingListener $listener;
 
@@ -71,18 +68,18 @@ class ClickjackingListenerTest extends TestCase
         $request = Request::create('/');
         $response = new RedirectResponse('/redirect');
 
-        $event = new ResponseEvent($this->createStub(HttpKernelInterface::class), $request, HttpKernelInterface::MASTER_REQUEST, $response);
+        $event = $this->createResponseEvent($request, true, $response);
         $this->listener->onKernelResponse($event);
         $this->assertSame(null, $response->headers->get('X-Frame-Options'));
     }
 
-    protected function callListener(ClickjackingListener $listener, string $path, bool $masterReq, string $contentType = 'text/html'): Response
+    protected function callListener(ClickjackingListener $listener, string $path, bool $mainReq, string $contentType = 'text/html'): Response
     {
         $request = Request::create($path);
         $response = new Response();
         $response->headers->add(['content-type' => $contentType]);
 
-        $event = new ResponseEvent($this->createStub(HttpKernelInterface::class), $request, $masterReq ? HttpKernelInterface::MASTER_REQUEST : HttpKernelInterface::SUB_REQUEST, $response);
+        $event = $this->createResponseEvent($request, $mainReq, $response);
         $listener->onKernelResponse($event);
 
         return $response;

--- a/tests/Listener/ContentTypeListenerTest.php
+++ b/tests/Listener/ContentTypeListenerTest.php
@@ -14,13 +14,10 @@ declare(strict_types=1);
 namespace Nelmio\SecurityBundle\Tests\Listener;
 
 use Nelmio\SecurityBundle\EventListener\ContentTypeListener;
-use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpKernel\Event\ResponseEvent;
-use Symfony\Component\HttpKernel\HttpKernelInterface;
 
-class ContentTypeListenerTest extends TestCase
+class ContentTypeListenerTest extends ListenerTestCase
 {
     public function testNoSniff(): void
     {
@@ -43,12 +40,12 @@ class ContentTypeListenerTest extends TestCase
         );
     }
 
-    protected function callListener(ContentTypeListener $listener, string $path, bool $masterReq): Response
+    protected function callListener(ContentTypeListener $listener, string $path, bool $mainReq): Response
     {
         $request = Request::create($path);
         $response = new Response();
 
-        $event = new ResponseEvent($this->createStub(HttpKernelInterface::class), $request, $masterReq ? HttpKernelInterface::MASTER_REQUEST : HttpKernelInterface::SUB_REQUEST, $response);
+        $event = $this->createResponseEvent($request, $mainReq, $response);
         $listener->onKernelResponse($event);
 
         return $response;

--- a/tests/Listener/ExternalRedirectListenerTest.php
+++ b/tests/Listener/ExternalRedirectListenerTest.php
@@ -15,14 +15,11 @@ namespace Nelmio\SecurityBundle\Tests\Listener;
 
 use Nelmio\SecurityBundle\EventListener\ExternalRedirectListener;
 use Nelmio\SecurityBundle\ExternalRedirect\WhitelistBasedTargetValidator;
-use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Symfony\Component\HttpKernel\Exception\HttpException;
-use Symfony\Component\HttpKernel\HttpKernelInterface;
 
-class ExternalRedirectListenerTest extends TestCase
+class ExternalRedirectListenerTest extends ListenerTestCase
 {
     /**
      * @dataProvider provideRedirectMatcher
@@ -169,7 +166,7 @@ class ExternalRedirectListenerTest extends TestCase
 
         $response = new RedirectResponse('http://foo.com/');
 
-        $event = new ResponseEvent($this->createStub(HttpKernelInterface::class), $request, HttpKernelInterface::SUB_REQUEST, $response);
+        $event = $this->createResponseEvent($request, false, $response);
         $listener->onKernelResponse($event);
 
         $this->assertTrue($response->isRedirect());
@@ -182,7 +179,7 @@ class ExternalRedirectListenerTest extends TestCase
 
         $response = new RedirectResponse($target);
 
-        $event = new ResponseEvent($this->createStub(HttpKernelInterface::class), $request, HttpKernelInterface::MASTER_REQUEST, $response);
+        $event = $this->createResponseEvent($request, true, $response);
         $listener->onKernelResponse($event);
 
         return $response;

--- a/tests/Listener/FlexibleSslListenerTest.php
+++ b/tests/Listener/FlexibleSslListenerTest.php
@@ -15,19 +15,16 @@ namespace Nelmio\SecurityBundle\Tests\Listener;
 
 use Nelmio\SecurityBundle\EventListener\FlexibleSslListener;
 use PHPUnit\Framework\MockObject\Stub;
-use PHPUnit\Framework\TestCase;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\Cookie;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\ResponseHeaderBag;
-use Symfony\Component\HttpKernel\Event\RequestEvent;
-use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 
-class FlexibleSslListenerTest extends TestCase
+class FlexibleSslListenerTest extends ListenerTestCase
 {
     /**
      * @var Stub&HttpKernelInterface
@@ -51,7 +48,7 @@ class FlexibleSslListenerTest extends TestCase
     {
         $request = Request::create('http://localhost/');
 
-        $event = new RequestEvent($this->kernel, $request, HttpKernelInterface::MASTER_REQUEST);
+        $event = $this->createRequestEventWithKernel($this->kernel, $request, true);
         $this->listener->onKernelRequest($event);
 
         $this->assertFalse($event->hasResponse());
@@ -62,7 +59,7 @@ class FlexibleSslListenerTest extends TestCase
         $request = Request::create('http://localhost/');
         $request->cookies->set('auth', '1');
 
-        $event = new RequestEvent($this->kernel, $request, HttpKernelInterface::MASTER_REQUEST);
+        $event = $this->createRequestEventWithKernel($this->kernel, $request, true);
         $this->listener->onKernelRequest($event);
 
         $this->assertTrue($event->hasResponse());
@@ -74,7 +71,7 @@ class FlexibleSslListenerTest extends TestCase
     {
         $request = Request::create('https://localhost/');
 
-        $event = new RequestEvent($this->kernel, $request, HttpKernelInterface::MASTER_REQUEST);
+        $event = $this->createRequestEventWithKernel($this->kernel, $request, true);
         $this->listener->onKernelRequest($event);
 
         $this->assertFalse($event->hasResponse());
@@ -85,7 +82,7 @@ class FlexibleSslListenerTest extends TestCase
         $request = Request::create('https://localhost/');
         $request->cookies->set('auth', '1');
 
-        $event = new RequestEvent($this->kernel, $request, HttpKernelInterface::MASTER_REQUEST);
+        $event = $this->createRequestEventWithKernel($this->kernel, $request, true);
         $this->listener->onKernelRequest($event);
 
         $this->assertFalse($event->hasResponse());
@@ -97,7 +94,7 @@ class FlexibleSslListenerTest extends TestCase
 
         $response = new Response();
 
-        $event = new ResponseEvent($this->kernel, $request, HttpKernelInterface::MASTER_REQUEST, $response);
+        $event = $this->createResponseEventWithKernel($this->kernel, $request, true, $response);
         $this->listener->onPostLoginKernelResponse($event);
 
         $cookies = $response->headers->getCookies(ResponseHeaderBag::COOKIES_ARRAY);
@@ -125,7 +122,7 @@ class FlexibleSslListenerTest extends TestCase
         $response = new Response();
         $response->headers->setCookie($unsecureCookie);
 
-        $event = new ResponseEvent($this->kernel, $request, HttpKernelInterface::MASTER_REQUEST, $response);
+        $event = $this->createResponseEventWithKernel($this->kernel, $request, true, $response);
         $this->listener->onPostLoginKernelResponse($event);
 
         $cookies = $response->headers->getCookies(ResponseHeaderBag::COOKIES_ARRAY);
@@ -139,7 +136,7 @@ class FlexibleSslListenerTest extends TestCase
         $request = Request::create('http://localhost/');
         $request->cookies->set('auth', '1');
 
-        $event = new RequestEvent($this->kernel, $request, HttpKernelInterface::SUB_REQUEST);
+        $event = $this->createRequestEventWithKernel($this->kernel, $request, false);
         $this->listener->onKernelRequest($event);
 
         $this->assertFalse($event->hasResponse());
@@ -151,7 +148,7 @@ class FlexibleSslListenerTest extends TestCase
 
         $response = new Response();
 
-        $event = new ResponseEvent($this->kernel, $request, HttpKernelInterface::SUB_REQUEST, $response);
+        $event = $this->createResponseEventWithKernel($this->kernel, $request, false, $response);
         $this->listener->onPostLoginKernelResponse($event);
 
         $cookies = $response->headers->getCookies(ResponseHeaderBag::COOKIES_ARRAY);

--- a/tests/Listener/ForcedSslListenerTest.php
+++ b/tests/Listener/ForcedSslListenerTest.php
@@ -14,14 +14,10 @@ declare(strict_types=1);
 namespace Nelmio\SecurityBundle\Tests\Listener;
 
 use Nelmio\SecurityBundle\EventListener\ForcedSslListener;
-use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpKernel\Event\RequestEvent;
-use Symfony\Component\HttpKernel\Event\ResponseEvent;
-use Symfony\Component\HttpKernel\HttpKernelInterface;
 
-class ForcedSslListenerTest extends TestCase
+class ForcedSslListenerTest extends ListenerTestCase
 {
     /**
      * @dataProvider provideHstsHeaders
@@ -114,22 +110,22 @@ class ForcedSslListenerTest extends TestCase
         $this->assertSame(301, $response->getStatusCode());
     }
 
-    private function callListenerReq(ForcedSslListener $listener, string $uri, bool $masterReq): ?Response
+    private function callListenerReq(ForcedSslListener $listener, string $uri, bool $mainReq): ?Response
     {
         $request = Request::create($uri);
 
-        $event = new RequestEvent($this->createStub(HttpKernelInterface::class), $request, $masterReq ? HttpKernelInterface::MASTER_REQUEST : HttpKernelInterface::SUB_REQUEST);
+        $event = $this->createRequestEvent($request, $mainReq);
         $listener->onKernelRequest($event);
 
         return $event->getResponse();
     }
 
-    private function callListenerResp(ForcedSslListener $listener, string $uri, bool $masterReq): Response
+    private function callListenerResp(ForcedSslListener $listener, string $uri, bool $mainReq): Response
     {
         $request = Request::create($uri);
         $response = new Response();
 
-        $event = new ResponseEvent($this->createStub(HttpKernelInterface::class), $request, $masterReq ? HttpKernelInterface::MASTER_REQUEST : HttpKernelInterface::SUB_REQUEST, $response);
+        $event = $this->createResponseEvent($request, $mainReq, $response);
         $listener->onKernelResponse($event);
 
         return $response;

--- a/tests/Listener/ListenerTestCase.php
+++ b/tests/Listener/ListenerTestCase.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Nelmio SecurityBundle.
+ *
+ * (c) Nelmio <hello@nelm.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\SecurityBundle\Tests\Listener;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+
+abstract class ListenerTestCase extends TestCase
+{
+    protected function createRequestEventWithKernel(
+        HttpKernelInterface $httpKernel,
+        Request $request,
+        bool $mainRequest
+    ): RequestEvent {
+        return new RequestEvent(
+            $httpKernel,
+            $request,
+            $this->getRequestType($mainRequest),
+        );
+    }
+
+    protected function createRequestEvent(
+        Request $request,
+        bool $mainRequest
+    ): RequestEvent {
+        return new RequestEvent(
+            $this->createStub(HttpKernelInterface::class),
+            $request,
+            $this->getRequestType($mainRequest),
+        );
+    }
+
+    protected function createResponseEventWithKernel(
+        HttpKernelInterface $httpKernel,
+        Request $request,
+        bool $mainRequest,
+        Response $response
+    ): ResponseEvent {
+        return new ResponseEvent(
+            $httpKernel,
+            $request,
+            $this->getRequestType($mainRequest),
+            $response
+        );
+    }
+
+    protected function createResponseEvent(
+        Request $request,
+        bool $mainRequest,
+        Response $response
+    ): ResponseEvent {
+        return new ResponseEvent(
+            $this->createStub(HttpKernelInterface::class),
+            $request,
+            $this->getRequestType($mainRequest),
+            $response
+        );
+    }
+
+    private function getRequestType(bool $mainRequest): int
+    {
+        if (!$mainRequest) {
+            return HttpKernelInterface::SUB_REQUEST;
+        }
+
+        return defined(HttpKernelInterface::class.'::MAIN_REQUEST')
+            ? HttpKernelInterface::MAIN_REQUEST
+            : HttpKernelInterface::MASTER_REQUEST
+            ;
+    }
+}

--- a/tests/Listener/ReferrerPolicyListenerTest.php
+++ b/tests/Listener/ReferrerPolicyListenerTest.php
@@ -14,13 +14,10 @@ declare(strict_types=1);
 namespace Nelmio\SecurityBundle\Tests\Listener;
 
 use Nelmio\SecurityBundle\EventListener\ReferrerPolicyListener;
-use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpKernel\Event\ResponseEvent;
-use Symfony\Component\HttpKernel\HttpKernelInterface;
 
-class ReferrerPolicyListenerTest extends TestCase
+class ReferrerPolicyListenerTest extends ListenerTestCase
 {
     /**
      * @dataProvider provideVariousConfigs
@@ -42,15 +39,14 @@ class ReferrerPolicyListenerTest extends TestCase
         ];
     }
 
-    protected function callListener(ReferrerPolicyListener $listener, string $path, bool $masterReq): Response
+    protected function callListener(ReferrerPolicyListener $listener, string $path, bool $mainReq): Response
     {
         $request = Request::create($path);
         $response = new Response();
 
-        $event = new ResponseEvent(
-            $this->createStub(HttpKernelInterface::class),
+        $event = $this->createResponseEvent(
             $request,
-            $masterReq ? HttpKernelInterface::MASTER_REQUEST : HttpKernelInterface::SUB_REQUEST,
+            $mainReq,
             $response
         );
         $listener->onKernelResponse($event);

--- a/tests/Listener/XssProtectionListenerTest.php
+++ b/tests/Listener/XssProtectionListenerTest.php
@@ -14,14 +14,11 @@ declare(strict_types=1);
 namespace Nelmio\SecurityBundle\Tests\Listener;
 
 use Nelmio\SecurityBundle\EventListener\XssProtectionListener;
-use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpKernel\Event\ResponseEvent;
-use Symfony\Component\HttpKernel\HttpKernelInterface;
 
-class XssProtectionListenerTest extends TestCase
+class XssProtectionListenerTest extends ListenerTestCase
 {
     /**
      * @dataProvider provideVariousConfigs
@@ -51,10 +48,9 @@ class XssProtectionListenerTest extends TestCase
 
         $listener = new XssProtectionListener(true, true);
 
-        $event = new ResponseEvent(
-            $this->createStub(HttpKernelInterface::class),
+        $event = $this->createResponseEvent(
             $request,
-            HttpKernelInterface::MASTER_REQUEST,
+            true,
             $response
         );
         $listener->onKernelResponse($event);
@@ -62,15 +58,14 @@ class XssProtectionListenerTest extends TestCase
         $this->assertFalse($response->headers->has('X-Xss-Protection'));
     }
 
-    protected function callListener(XssProtectionListener $listener, string $path, bool $masterReq): Response
+    protected function callListener(XssProtectionListener $listener, string $path, bool $mainReq): Response
     {
         $request = Request::create($path);
         $response = new Response();
 
-        $event = new ResponseEvent(
-            $this->createStub(HttpKernelInterface::class),
+        $event = $this->createResponseEvent(
             $request,
-            $masterReq ? HttpKernelInterface::MASTER_REQUEST : HttpKernelInterface::SUB_REQUEST,
+            $mainReq,
             $response
         );
         $listener->onKernelResponse($event);

--- a/tests/Session/CookieSessionHandlerTest.php
+++ b/tests/Session/CookieSessionHandlerTest.php
@@ -14,17 +14,15 @@ declare(strict_types=1);
 namespace Nelmio\SecurityBundle\Tests\Session;
 
 use Nelmio\SecurityBundle\Session\CookieSessionHandler;
+use Nelmio\SecurityBundle\Tests\Listener\ListenerTestCase;
 use PHPUnit\Framework\MockObject\Stub;
-use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\ResponseHeaderBag;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
-use Symfony\Component\HttpKernel\Event\RequestEvent;
-use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 
-class CookieSessionHandlerTest extends TestCase
+class CookieSessionHandlerTest extends ListenerTestCase
 {
     private CookieSessionHandler $handler;
 
@@ -62,13 +60,13 @@ class CookieSessionHandlerTest extends TestCase
         $session->expects($this->once())->method('save');
         $request->setSession($session);
 
-        $this->handler->onKernelRequest(new RequestEvent($this->kernel, $request, HttpKernelInterface::MASTER_REQUEST));
+        $this->handler->onKernelRequest($this->createRequestEventWithKernel($this->kernel, $request, true));
 
         $this->assertTrue($this->handler->open('foo', 'bar'));
 
         $this->handler->write('sessionId', 'mydata');
 
-        $this->handler->onKernelResponse(new ResponseEvent($this->kernel, $request, HttpKernelInterface::MASTER_REQUEST, $response));
+        $this->handler->onKernelResponse($this->createResponseEventWithKernel($this->kernel, $request, true, $response));
 
         $cookies = $response->headers->getCookies();
 
@@ -87,9 +85,9 @@ class CookieSessionHandlerTest extends TestCase
         $session->expects($this->exactly(2))->method('save');
         $request->setSession($session);
 
-        $this->handler->onKernelRequest(new RequestEvent($this->kernel, $request, HttpKernelInterface::MASTER_REQUEST));
+        $this->handler->onKernelRequest($this->createRequestEventWithKernel($this->kernel, $request, true));
 
-        $this->handler->onKernelResponse(new ResponseEvent($this->kernel, $request, HttpKernelInterface::MASTER_REQUEST, $response));
+        $this->handler->onKernelResponse($this->createResponseEventWithKernel($this->kernel, $request, true, $response));
 
         $cookies = $response->headers->getCookies();
 
@@ -99,7 +97,7 @@ class CookieSessionHandlerTest extends TestCase
 
         $this->handler->destroy('sessionId');
 
-        $this->handler->onKernelResponse(new ResponseEvent($this->kernel, $request, HttpKernelInterface::MASTER_REQUEST, $response));
+        $this->handler->onKernelResponse($this->createResponseEventWithKernel($this->kernel, $request, true, $response));
 
         $cookies = $response->headers->getCookies();
 
@@ -125,9 +123,9 @@ class CookieSessionHandlerTest extends TestCase
         $request->setSession($session);
         $response->headers = $headers;
 
-        $this->handler->onKernelRequest(new RequestEvent($this->kernel, $request, HttpKernelInterface::MASTER_REQUEST));
+        $this->handler->onKernelRequest($this->createRequestEventWithKernel($this->kernel, $request, true));
 
-        $this->handler->onKernelResponse(new ResponseEvent($this->kernel, $request, HttpKernelInterface::MASTER_REQUEST, $response));
+        $this->handler->onKernelResponse($this->createResponseEventWithKernel($this->kernel, $request, true, $response));
 
         $getCookie = \Closure::bind(static function (CookieSessionHandler $handler) {
             return $handler->cookie;


### PR DESCRIPTION
Uses the same strategy as https://github.com/getsentry/sentry-symfony/blob/dd37786fc7ca81a4320e6d9812ff549104193043/src/EventListener/KernelEventForwardCompatibilityTrait.php