### PR TITLE
Rename `Event` to `ReportEvent`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 * Log user agent along with CSP report
 * Deprecated external_redirects.whitelist option in favor of external_redirects.allow_list
 * Deprecated forced_ssl.whitelist option in favor of forced_ssl.allow_list
+* Deprecated `Nelmio\SecurityBundle\ContentSecurityPolicy\Violation\Event` class in favor of
+  `Nelmio\SecurityBundle\ContentSecurityPolicy\Violation\ReportEvent`.
 
 ### 2.11.0 (2022-01-18)
   * Added support for CSP "prefetch-src" directive

--- a/ContentSecurityPolicy/Violation/Event.php
+++ b/ContentSecurityPolicy/Violation/Event.php
@@ -27,6 +27,9 @@ if (\class_exists(\Symfony\Component\EventDispatcher\Event::class)) {
     }
 }
 
+/**
+ * @deprecated since nelmio/security-bundle 2.12, use ReportEvent instead.
+ */
 class Event extends BaseEvent
 {
     private $report;

--- a/ContentSecurityPolicy/Violation/ReportEvent.php
+++ b/ContentSecurityPolicy/Violation/ReportEvent.php
@@ -11,10 +11,6 @@
 
 namespace Nelmio\SecurityBundle\ContentSecurityPolicy\Violation;
 
-final class Events
+final class ReportEvent extends Event
 {
-    /**
-     * @deprecated since nelmio/security-bundle 2.12, use `ReportEvent::class` instead.
-     */
-    const VIOLATION_REPORT = 'csp.violation.report';
 }

--- a/Controller/ContentSecurityPolicyController.php
+++ b/Controller/ContentSecurityPolicyController.php
@@ -17,6 +17,7 @@ use Nelmio\SecurityBundle\ContentSecurityPolicy\Violation\Exception\ExceptionInt
 use Nelmio\SecurityBundle\ContentSecurityPolicy\Violation\Filter\Filter;
 use Nelmio\SecurityBundle\ContentSecurityPolicy\Violation\Log\Logger;
 use Nelmio\SecurityBundle\ContentSecurityPolicy\Violation\Report;
+use Nelmio\SecurityBundle\ContentSecurityPolicy\Violation\ReportEvent;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface as LegacyEventDispatcherInterface;
 use Symfony\Component\HttpFoundation\Request;
@@ -72,9 +73,9 @@ class ContentSecurityPolicyController
 
         if ($this->dispatcher) {
             if ($this->dispatcher instanceof EventDispatcherInterface) {
-                $this->dispatcher->dispatch(new Event($report), Events::VIOLATION_REPORT);
+                $this->dispatcher->dispatch(new ReportEvent($report), Events::VIOLATION_REPORT);
             } else {
-                $this->dispatcher->dispatch(Events::VIOLATION_REPORT, new Event($report));
+                $this->dispatcher->dispatch(Events::VIOLATION_REPORT, new ReportEvent($report));
             }
         }
 

--- a/DependencyInjection/NelmioSecurityExtension.php
+++ b/DependencyInjection/NelmioSecurityExtension.php
@@ -135,7 +135,7 @@ class NelmioSecurityExtension extends Extension
                 }
 
                 @trigger_error(
-                    'external_redirects.whitelist configuration is deprecated and will not work in 3.0, use external_redirects.allow_list instead.',
+                    'external_redirects.whitelist configuration option is deprecated since nelmio/security-bundle 2.12 and will not work in 3.0, use external_redirects.allow_list instead.',
                     E_USER_DEPRECATED
                 );
 
@@ -197,7 +197,7 @@ class NelmioSecurityExtension extends Extension
                 }
 
                 @trigger_error(
-                    'forced_ssl.whitelist configuration is deprecated and will not work in 3.0, use forced_ssl.allow_list instead.',
+                    'forced_ssl.whitelist configuration option is deprecated since nelmio/security-bundle 2.12 and will not work in 3.0, use forced_ssl.allow_list instead.',
                     E_USER_DEPRECATED
                 );
 

--- a/NelmioSecurityBundle.php
+++ b/NelmioSecurityBundle.php
@@ -11,8 +11,11 @@
 
 namespace Nelmio\SecurityBundle;
 
+use Nelmio\SecurityBundle\ContentSecurityPolicy\Violation\Events;
+use Nelmio\SecurityBundle\ContentSecurityPolicy\Violation\ReportEvent;
 use Nelmio\SecurityBundle\DependencyInjection\Compiler\CspReportFilterCompilerPass;
 use Nelmio\SecurityBundle\DependencyInjection\Compiler\UAParserCompilerPass;
+use Symfony\Component\EventDispatcher\DependencyInjection\AddEventAliasesPass;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
@@ -24,5 +27,11 @@ class NelmioSecurityBundle extends Bundle
 
         $container->addCompilerPass(new UAParserCompilerPass());
         $container->addCompilerPass(new CspReportFilterCompilerPass());
+
+        if (class_exists(AddEventAliasesPass::class)) {
+            $container->addCompilerPass(new AddEventAliasesPass([
+                ReportEvent::class => Events::VIOLATION_REPORT,
+            ]));
+        }
     }
 }

--- a/Tests/ContentSecurityPolicy/Violation/ReportEventTest.php
+++ b/Tests/ContentSecurityPolicy/Violation/ReportEventTest.php
@@ -2,17 +2,17 @@
 
 namespace ContentSecurityPolicy\Violation;
 
-use Nelmio\SecurityBundle\ContentSecurityPolicy\Violation\Event;
 use Nelmio\SecurityBundle\ContentSecurityPolicy\Violation\Report;
+use Nelmio\SecurityBundle\ContentSecurityPolicy\Violation\ReportEvent;
 use PhpUnit\Framework\TestCase;
 
-class EventTest extends TestCase
+class ReportEventTest extends TestCase
 {
     public function testCanBeConstructed()
     {
         $this->assertInstanceOf(
-            Event::class,
-            new Event(new Report([]))
+            ReportEvent::class,
+            new ReportEvent(new Report([]))
         );
     }
 }


### PR DESCRIPTION
I think the name is better, instead of doing it directly in 3.0, deprecating `Event` would allow users to have a smooth upgrade path.