### PR TITLE
Update installation docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## About
 
-The NelmioSecurityBundle provides additional security features for your Symfony2 application.
+The NelmioSecurityBundle provides additional security features for your Symfony application.
 
 ## Installation
 
@@ -10,17 +10,41 @@ Require the `nelmio/security-bundle` package in your composer.json and update yo
 
     $ composer require nelmio/security-bundle
 
-Add the NelmioSecurityBundle to your application's kernel:
+The bundle should be automatically enabled by Flex. In case you don't use Flex, you'll need to manually enable the
+bundle by adding the following line in the config/bundles.php file of your project:
+```php
+<?php
+// config/bundles.php
+
+return [
+    // ...
+    Nelmio\SecurityBundle\NelmioSecurityBundle::class => ['all' => true],
+    // ...
+];
+```
+
+If you don't have a `config/bundles.php` file in your project, chances are that you're using an older Symfony version.
+In this case, you should have an `app/AppKernel.php` file instead. Edit such file:
 
 ```php
-public function registerBundles()
+<?php
+// app/AppKernel.php
+
+// ...
+class AppKernel extends Kernel
 {
-    $bundles = array(
-        ...
-        new Nelmio\SecurityBundle\NelmioSecurityBundle(),
-        ...
-    );
-    ...
+    public function registerBundles()
+    {
+        $bundles = [
+            // ...
+
+            new Nelmio\SecurityBundle\NelmioSecurityBundle(),
+        ];
+
+        // ...
+    }
+
+    // ...
 }
 ```
 
@@ -530,7 +554,8 @@ another URL:
 nelmio_security:
     external_redirects:
         override: home
-
+```
+```yaml
 # redirect to another URL
 nelmio_security:
     external_redirects:

--- a/src/EventListener/ContentSecurityPolicyListener.php
+++ b/src/EventListener/ContentSecurityPolicyListener.php
@@ -75,9 +75,6 @@ final class ContentSecurityPolicyListener extends AbstractContentTypeRestrictabl
         $this->sha = [];
     }
 
-    /**
-     * @internal
-     */
     public function addSha(string $directive, string $sha): void
     {
         if (null === $this->sha) {
@@ -89,9 +86,6 @@ final class ContentSecurityPolicyListener extends AbstractContentTypeRestrictabl
         $this->sha[$directive][] = $sha;
     }
 
-    /**
-     * @internal
-     */
     public function addScript(string $html): void
     {
         if (null === $this->sha) {
@@ -103,9 +97,6 @@ final class ContentSecurityPolicyListener extends AbstractContentTypeRestrictabl
         $this->sha['script-src'][] = $this->shaComputer->computeForScript($html);
     }
 
-    /**
-     * @internal
-     */
     public function addStyle(string $html): void
     {
         if (null === $this->sha) {
@@ -127,9 +118,6 @@ final class ContentSecurityPolicyListener extends AbstractContentTypeRestrictabl
         return $this->enforce;
     }
 
-    /**
-     * @internal
-     */
     public function getNonce(string $usage): string
     {
         $nonce = $this->doGetNonce();


### PR DESCRIPTION
I've reverted the `@internal` annotation on `ContentSecurityPolicyListener` since they can be use without Twig as indicated in docs.