### PR TITLE
Fixes for cookie signing

### DIFF
--- a/src/EventListener/SignedCookieListener.php
+++ b/src/EventListener/SignedCookieListener.php
@@ -72,7 +72,7 @@ final class SignedCookieListener
         $response = $e->getResponse();
 
         foreach ($response->headers->getCookies() as $cookie) {
-            if (true === $this->signedCookieNames || \in_array($cookie->getName(), $this->signedCookieNames, true)) {
+            if ($cookie->getValue() && (true === $this->signedCookieNames || \in_array($cookie->getName(), $this->signedCookieNames, true))) {
                 $response->headers->removeCookie($cookie->getName(), $cookie->getPath(), $cookie->getDomain());
                 $signedCookie = new Cookie(
                     $cookie->getName(),

--- a/src/Signer.php
+++ b/src/Signer.php
@@ -34,7 +34,7 @@ final class Signer
             $signature = $this->generateSignature($value);
         }
 
-        return $value.'.'.$signature;
+        return $value.','.$signature;
     }
 
     public function verifySignedValue(string $signedValue): bool
@@ -75,7 +75,7 @@ final class Signer
      */
     private function splitSignatureFromSignedValue(string $signedValue): array
     {
-        $pos = strrpos($signedValue, '.');
+        $pos = strrpos($signedValue, ',');
         if (false === $pos) {
             return [$signedValue, null];
         }

--- a/tests/Listener/SignedCookieListenerTest.php
+++ b/tests/Listener/SignedCookieListenerTest.php
@@ -61,8 +61,8 @@ class SignedCookieListenerTest extends ListenerTestCase
             [[], [], []],
             [[], ['foo' => 'bar'], ['foo' => 'bar']],
             [['foo'], ['foo' => 'bar'], []],
-            [['foo'], ['foo' => 'bar.ca3756f81d3728a023bdc8a622c0906f373b795e'], ['foo' => 'bar']],
-            [['*'], ['foo' => 'bar.ca3756f81d3728a023bdc8a622c0906f373b795e'], ['foo' => 'bar']],
+            [['foo'], ['foo' => 'bar,ca3756f81d3728a023bdc8a622c0906f373b795e'], ['foo' => 'bar']],
+            [['*'], ['foo' => 'bar,ca3756f81d3728a023bdc8a622c0906f373b795e'], ['foo' => 'bar']],
         ];
     }
 
@@ -99,8 +99,8 @@ class SignedCookieListenerTest extends ListenerTestCase
         return [
             [[], [], []],
             [[], ['foo' => 'bar'], ['foo' => 'bar']],
-            [['foo'], ['foo' => 'bar'], ['foo' => 'bar.ca3756f81d3728a023bdc8a622c0906f373b795e']],
-            [['*'], ['foo' => 'bar'], ['foo' => 'bar.ca3756f81d3728a023bdc8a622c0906f373b795e']],
+            [['foo'], ['foo' => 'bar'], ['foo' => 'bar,ca3756f81d3728a023bdc8a622c0906f373b795e']],
+            [['*'], ['foo' => 'bar'], ['foo' => 'bar,ca3756f81d3728a023bdc8a622c0906f373b795e']],
         ];
     }
 

--- a/tests/Listener/SignedCookieListenerTest.php
+++ b/tests/Listener/SignedCookieListenerTest.php
@@ -129,4 +129,19 @@ class SignedCookieListenerTest extends ListenerTestCase
         $cookies = $response->headers->getCookies(ResponseHeaderBag::COOKIES_ARRAY);
         $this->assertSame('bar', $cookies['']['/']['foo']->getValue());
     }
+
+    public function testCookieWritingHandlesEmptyValue(): void
+    {
+        $listener = new SignedCookieListener($this->signer, ['*']);
+        $request = Request::create('/');
+
+        $response = new Response();
+        $response->headers->setCookie(Cookie::create('foo'));
+
+        $event = $this->createResponseEventWithKernel($this->kernel, $request, true, $response);
+        $listener->onKernelResponse($event);
+
+        $cookies = $response->headers->getCookies(ResponseHeaderBag::COOKIES_ARRAY);
+        $this->assertNull($cookies['']['/']['foo']->getValue());
+    }
 }


### PR DESCRIPTION
I hit a problem with CSRF tokens being rejected as invalid on both login and Symfony Form submissions. 

After a lot of head scratching, I observed that multiple sessions were being created per request and that for some reason the session ID was being invalidated by NativeSessionStorage. 

See https://github.com/symfony/symfony/blob/6.1/src/Symfony/Component/HttpFoundation/Session/Storage/NativeSessionStorage.php#L169-L172 and the comment above does the job explaining why.

The changes in Symfony were introduced here https://github.com/symfony/symfony/pull/46249 and recently updated here https://github.com/symfony/symfony/pull/46790

**tl;dr** Using a dot as the value delimiter when signing cookies, and signing session cookies, will cause sessions to fail.

Finally, if signing cookies with an empty value causes an exception. So the second fix just  handles that case.

Fixes #154 
Fixes #312 
Fixes #313 
