### PR TITLE
Introduce `ExternalRedirectResponse`

### DIFF
--- a/src/EventListener/ExternalRedirectListener.php
+++ b/src/EventListener/ExternalRedirectListener.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Nelmio\SecurityBundle\EventListener;
 
 use Nelmio\SecurityBundle\ExternalRedirect\AllowListBasedTargetValidator;
+use Nelmio\SecurityBundle\ExternalRedirect\ExternalRedirectResponse;
 use Nelmio\SecurityBundle\ExternalRedirect\TargetValidator;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpKernel\Event\ResponseEvent;
@@ -84,6 +85,13 @@ final class ExternalRedirectListener
 
         if (!$this->isExternalRedirect($e->getRequest()->getUri(), $target)) {
             return;
+        }
+
+        if ($response instanceof ExternalRedirectResponse) {
+            $targetValidator = new AllowListBasedTargetValidator($response->getAllowedHosts());
+            if ($targetValidator->isTargetAllowed($target)) {
+                return;
+            }
         }
 
         if (null !== $this->targetValidator && $this->targetValidator->isTargetAllowed($target)) {

--- a/src/ExternalRedirect/ExternalRedirectResponse.php
+++ b/src/ExternalRedirect/ExternalRedirectResponse.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Nelmio\SecurityBundle\ExternalRedirect;
+
+use Symfony\Component\HttpFoundation\RedirectResponse;
+
+class ExternalRedirectResponse extends RedirectResponse
+{
+    /**
+     * @var string[]
+     */
+    private array $allowedHosts;
+
+    /**
+     * @param string[] $allowedHosts
+     * @param string[] $headers
+     */
+    public function __construct(string $url, array $allowedHosts, int $status = 302, array $headers = [])
+    {
+        $this->allowedHosts = $allowedHosts;
+        parent::__construct($url, $status, $headers);
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getAllowedHosts(): array
+    {
+        return $this->allowedHosts;
+    }
+}

--- a/src/ExternalRedirect/ExternalRedirectResponse.php
+++ b/src/ExternalRedirect/ExternalRedirectResponse.php
@@ -1,5 +1,16 @@
 <?php
 
+declare(strict_types=1);
+
+/*
+ * This file is part of the Nelmio SecurityBundle.
+ *
+ * (c) Nelmio <hello@nelm.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Nelmio\SecurityBundle\ExternalRedirect;
 
 use Symfony\Component\HttpFoundation\RedirectResponse;

--- a/src/Resources/doc/index.rst
+++ b/src/Resources/doc/index.rst
@@ -648,6 +648,32 @@ subdomains if needed.
                 - twitter.com
                 - facebook.com
 
+If you have a controller that can redirect to another host, you can also use `ExternalRedirectResponse` to allow the
+redirect without having to configure the hosts globally. Any hosts passed to `ExternalRedirectResponse` are in
+addition to those already configured globally.
+
+.. code-block:: yaml
+
+    # config/packages/nelmio_security.yaml
+    nelmio_security:
+        external_redirects:
+            abort: true
+            allow_list:
+                - bar.com
+
+.. code-block:: php
+
+    use Nelmio\SecurityBundle\ExternalRedirect\ExternalRedirectResponse;
+
+    // Will be allowed even though "foo.com" is not allowed globally through the config.
+    return new ExternalRedirectResponse('https://foo.com', ['foo.com', 'auth-provider.test']);
+
+    // Will not be allowed.
+    return new ExternalRedirectResponse('https://not-allowed.com', ['foo.com', 'auth-provider.test']);
+
+    // Will be allowed because "bar.com" is allowed globally through the config.
+    return new ExternalRedirectResponse('https://bar.com', ['foo.com', 'auth-provider.test']);
+
 Forced HTTPS/SSL Handling
 -------------------------
 


### PR DESCRIPTION
Introduces `ExternalRedirectResponse` to allow redirects to other hosts without the need to configure those hosts globally allowing for more fine-grained control.

Fixes #330.