### PR TITLE
Make data array variable type within `Report` more precise

### DIFF
--- a/src/ContentSecurityPolicy/Violation/Report.php
+++ b/src/ContentSecurityPolicy/Violation/Report.php
@@ -21,7 +21,7 @@ use Symfony\Component\HttpFoundation\Request;
 final class Report
 {
     /**
-     * @var array<string, string>
+     * @var array<string, int|string>
      */
     private array $data;
 

--- a/src/ContentSecurityPolicy/Violation/Report.php
+++ b/src/ContentSecurityPolicy/Violation/Report.php
@@ -115,7 +115,7 @@ final class Report
     }
 
     /**
-     * @return array<string, string>
+     * @return array<string, int|string>
      */
     public function getData(): array
     {


### PR DESCRIPTION
Just a minor issue that PHP stan found in our project:

```
Error: Parameter #1 $data of class Nelmio\SecurityBundle\ContentSecurityPolicy\Violation\Report constructor expects array<string, string>, array<string, int|string> given.
 ------ ---------------------------------------------------------------------- 
  Line   core-bundle/tests/EventListener/CspReportListenerTest.php             
 ------ ---------------------------------------------------------------------- 
  47     Parameter #1 $data of class                                           
         Nelmio\SecurityBundle\ContentSecurityPolicy\Violation\Report          
         constructor expects array<string, string>, array<string, int|string>  
         given.                                                                
 ------ ---------------------------------------------------------------------- 
```

The JSON data sent by the browser can in fact also have integers for the following keys:

* `column-number`
* `line-number`
* `status-code`