### PR TITLE
Filter `view-source` reports

### DIFF
--- a/src/ContentSecurityPolicy/Violation/Filter/BrowserBugsNoiseDetector.php
+++ b/src/ContentSecurityPolicy/Violation/Filter/BrowserBugsNoiseDetector.php
@@ -55,6 +55,11 @@ final class BrowserBugsNoiseDetector implements NoiseDetectorInterface
             }
         }
 
+        // https://bugzilla.mozilla.org/show_bug.cgi?id=1873553
+        if ('view-source' === $report->getSourceFile()) {
+            return true;
+        }
+
         // files loaded by safari & firefox extension
         // should be allowed as in Chrome
         if (

--- a/tests/ContentSecurityPolicy/Violation/FilterTest.php
+++ b/tests/ContentSecurityPolicy/Violation/FilterTest.php
@@ -229,6 +229,11 @@ window.AG_onLoad = function(func)',
                 'blocked-uri' => 'www.gstatic.com',
                 'effective-directive' => 'script-src',
             ]],
+            [true, new Request(), [
+                'blocked-uri' => 'inline',
+                'source-file' => 'view-source',
+                'effective-directive' => 'style-src-attr',
+            ]]
         ];
     }
 }

--- a/tests/ContentSecurityPolicy/Violation/FilterTest.php
+++ b/tests/ContentSecurityPolicy/Violation/FilterTest.php
@@ -233,7 +233,7 @@ window.AG_onLoad = function(func)',
                 'blocked-uri' => 'inline',
                 'source-file' => 'view-source',
                 'effective-directive' => 'style-src-attr',
-            ]]
+            ]],
         ];
     }
 }


### PR DESCRIPTION
Firefox reports a CSP violation on the `view-source` view for any URL with a Content-Security-Policy directive for `default-src` or `style-src` (except `unsafe-inline` of course) - and also sends a CSP report to the `report-uri`. This PR filters any reports sent from `view-source` views.