### PR TITLE
Do not add signatures if `unsafe-inline` is enabled

### DIFF
--- a/src/ContentSecurityPolicy/DirectiveSet.php
+++ b/src/ContentSecurityPolicy/DirectiveSet.php
@@ -139,7 +139,10 @@ final class DirectiveSet
                 // let's ensure that it's backward compatible with CSP level 1 (all browsers are not compatible)
                 // this is the recommended way to deal with this.
                 if (false === strpos($value, '\'unsafe-inline\'') && $this->level1Fallback) {
-                    $policy[] = $name.' '.$value.' \'unsafe-inline\' '.$signatures[$name];
+                    $policy[] = $name.' '.$value.' '.'\'unsafe-inline\' '.$signatures[$name];
+                // Do not add any signatures if 'unsafe-inline' is allowed anyway
+                } elseif (false !== strpos($value, '\'unsafe-inline\'')) {
+                    $policy[] = $name.' '.$value;
                 } else {
                     $policy[] = $name.' '.$value.' '.$signatures[$name];
                 }

--- a/tests/ContentSecurityPolicy/DirectiveSetTest.php
+++ b/tests/ContentSecurityPolicy/DirectiveSetTest.php
@@ -374,7 +374,7 @@ class DirectiveSetTest extends TestCase
     {
         return [
             [
-                'default-src \'self\'; script-src \'self\' \'unsafe-inline\' \'sha-1\'; style-src \'self\' \'unsafe-inline\' \'sha2\'',
+                'default-src \'self\'; script-src \'self\' \'unsafe-inline\'; style-src \'self\' \'unsafe-inline\' \'sha2\'',
                 [
                     'enforce' => [
                         'level1_fallback' => true,

--- a/tests/Listener/ContentSecurityPolicyListenerTest.php
+++ b/tests/Listener/ContentSecurityPolicyListenerTest.php
@@ -87,13 +87,13 @@ class ContentSecurityPolicyListenerTest extends ListenerTestCase
         );
     }
 
-    public function testEvenWithUnsafeInlineItAppliesSignature(): void
+    public function testDoesNotApplySignatureWithUnsafeInline(): void
     {
         $listener = $this->buildSimpleListener(['default-src' => "default.example.org 'self'", 'script-src' => "'self' 'unsafe-inline'"]);
         $response = $this->callListener($listener, '/', true, 'text/html', ['signatures' => ['script-src' => ['sha-1']]]);
 
         $this->assertSame(
-            "default-src default.example.org 'self'; script-src 'self' 'unsafe-inline' 'sha-1'",
+            "default-src default.example.org 'self'; script-src 'self' 'unsafe-inline'",
             $response->headers->get('Content-Security-Policy')
         );
     }


### PR DESCRIPTION
Currently signatures are explicitly still added, even if `unsafe-inline` was already present in the `script-src` or `style-src` directive. However, if your application adds a lot of hashes (for `style="…"` for example) and you decide to instead allow `unsafe-inline` in general, the hashes are still output in the response header. This might lead to the response header size being too large, if there are a lot of long hashes for example

This PR would automatically _not_ apply any signatures, if `unsafe-inline` was enabled.

wdyt?