### PR TITLE
Introduce `DirectiveSetBuilderInterface` to allow runtime modification

### DIFF
--- a/src/ContentSecurityPolicy/ConfigurationDirectiveSetBuilder.php
+++ b/src/ContentSecurityPolicy/ConfigurationDirectiveSetBuilder.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Nelmio SecurityBundle.
+ *
+ * (c) Nelmio <hello@nelm.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\SecurityBundle\ContentSecurityPolicy;
+
+class ConfigurationDirectiveSetBuilder implements DirectiveSetBuilderInterface
+{
+    private PolicyManager $policyManager;
+
+    /**
+     * @phpstan-var array{
+     *       enforce?: array<string, mixed>,
+     *       report?: array<string, mixed>,
+     *   } $config
+     */
+    private array $config;
+
+    /**
+     * @phpstan-var 'enforce'|'report' $kind
+     */
+    private string $kind;
+
+    /**
+     * @phpstan-param array{
+     *      enforce?: array<string, mixed>,
+     *      report?: array<string, mixed>,
+     *  } $config
+     * @phpstan-param 'enforce'|'report' $kind
+     */
+    public function __construct(PolicyManager $policyManager, array $config, string $kind)
+    {
+        $this->policyManager = $policyManager;
+        $this->config = $config;
+        $this->kind = $kind;
+    }
+
+    public function buildDirectiveSet(): DirectiveSet
+    {
+        return DirectiveSet::fromConfig($this->policyManager, $this->config, $this->kind);
+    }
+
+    /**
+     * @phpstan-param array{
+     *     enforce?: array<string, mixed>,
+     *     report?: array<string, mixed>,
+     * } $config
+     * @phpstan-param 'enforce'|'report' $kind
+     */
+    public static function create(PolicyManager $policyManager, array $config, string $kind): self
+    {
+        return new self($policyManager, $config, $kind);
+    }
+}

--- a/src/ContentSecurityPolicy/DirectiveSetBuilderInterface.php
+++ b/src/ContentSecurityPolicy/DirectiveSetBuilderInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Nelmio SecurityBundle.
+ *
+ * (c) Nelmio <hello@nelm.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\SecurityBundle\ContentSecurityPolicy;
+
+interface DirectiveSetBuilderInterface
+{
+    public function buildDirectiveSet(): DirectiveSet;
+}

--- a/src/ContentSecurityPolicy/LegacyDirectiveSetBuilder.php
+++ b/src/ContentSecurityPolicy/LegacyDirectiveSetBuilder.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Nelmio SecurityBundle.
+ *
+ * (c) Nelmio <hello@nelm.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\SecurityBundle\ContentSecurityPolicy;
+
+/**
+ * @internal
+ */
+class LegacyDirectiveSetBuilder implements DirectiveSetBuilderInterface
+{
+    private DirectiveSet $directiveSet;
+
+    public function __construct(DirectiveSet $directiveSet)
+    {
+        $this->directiveSet = $directiveSet;
+    }
+
+    public function buildDirectiveSet(): DirectiveSet
+    {
+        return clone $this->directiveSet;
+    }
+}

--- a/src/DependencyInjection/NelmioSecurityExtension.php
+++ b/src/DependencyInjection/NelmioSecurityExtension.php
@@ -13,7 +13,8 @@ declare(strict_types=1);
 
 namespace Nelmio\SecurityBundle\DependencyInjection;
 
-use Nelmio\SecurityBundle\ContentSecurityPolicy\DirectiveSet;
+use Nelmio\SecurityBundle\ContentSecurityPolicy\ConfigurationDirectiveSetBuilder;
+use Nelmio\SecurityBundle\ContentSecurityPolicy\DirectiveSetBuilderInterface;
 use Symfony\Component\Config\Definition\Processor;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -50,11 +51,17 @@ final class NelmioSecurityExtension extends Extension
 
             $cspConfig = $config['csp'];
 
-            $enforceDefinition = $this->buildDirectiveSetDefinition($container, $cspConfig, 'enforce');
-            $reportDefinition = $this->buildDirectiveSetDefinition($container, $cspConfig, 'report');
+            $enforceDefinition = $this->createDirectiveSetBuilder($container, $cspConfig, 'enforce');
+            $reportDefinition = $this->createDirectiveSetBuilder($container, $cspConfig, 'report');
+
+            $container->addDefinitions([
+                'nelmio_security.directive_set_builder.report' => $reportDefinition,
+                'nelmio_security.directive_set_builder.enforce' => $enforceDefinition,
+            ]);
 
             $cspListenerDefinition = $container->getDefinition('nelmio_security.csp_listener');
-            $cspListenerDefinition->setArguments([$reportDefinition, $enforceDefinition, new Reference('nelmio_security.nonce_generator'), new Reference('nelmio_security.sha_computer'), (bool) $cspConfig['compat_headers'], $cspConfig['hosts'], $cspConfig['content_types']]);
+            $cspListenerDefinition->setArguments([new Reference('nelmio_security.directive_set_builder.report'), new Reference('nelmio_security.directive_set_builder.enforce'), new Reference('nelmio_security.nonce_generator'), new Reference('nelmio_security.sha_computer'), (bool) $cspConfig['compat_headers'], $cspConfig['hosts'], $cspConfig['content_types']]);
+
             $container->setParameter('nelmio_security.csp.hash_algorithm', $cspConfig['hash']['algorithm']);
 
             if (isset($cspConfig['request_matcher'])) {
@@ -179,11 +186,11 @@ final class NelmioSecurityExtension extends Extension
      * } $config
      * @phpstan-param 'enforce'|'report' $type
      */
-    private function buildDirectiveSetDefinition(ContainerBuilder $container, array $config, string $type): Definition
+    private function createDirectiveSetBuilder(ContainerBuilder $container, array $config, string $type): Definition
     {
-        $directiveDefinition = new Definition(DirectiveSet::class);
+        $builderDefinition = new Definition(DirectiveSetBuilderInterface::class);
 
-        $directiveDefinition->setFactory([DirectiveSet::class, 'fromConfig']);
+        $builderDefinition->setFactory([ConfigurationDirectiveSetBuilder::class, 'create']);
 
         $pmDefinition = $container->getDefinition('nelmio_security.policy_manager');
 
@@ -198,8 +205,8 @@ final class NelmioSecurityExtension extends Extension
             $pmDefinition->setArguments([new Reference('nelmio_security.ua_parser')]);
         }
 
-        $directiveDefinition->setArguments([$pmDefinition, $config, $type]);
+        $builderDefinition->setArguments([$pmDefinition, $config, $type]);
 
-        return $directiveDefinition;
+        return $builderDefinition;
     }
 }

--- a/src/EventListener/ContentSecurityPolicyListener.php
+++ b/src/EventListener/ContentSecurityPolicyListener.php
@@ -256,7 +256,7 @@ final class ContentSecurityPolicyListener extends AbstractContentTypeRestrictabl
         if ($builderOrDirectiveSet instanceof DirectiveSet) {
             trigger_deprecation(
                 'nelmio/security-bundle',
-                '3.3',
+                '3.5',
                 sprintf(
                     'Passing %s directly to the %s constructor is deprecated and will be removed in 4.0. Pass a %s instead.',
                     DirectiveSet::class,

--- a/src/EventListener/ContentSecurityPolicyListener.php
+++ b/src/EventListener/ContentSecurityPolicyListener.php
@@ -14,6 +14,8 @@ declare(strict_types=1);
 namespace Nelmio\SecurityBundle\EventListener;
 
 use Nelmio\SecurityBundle\ContentSecurityPolicy\DirectiveSet;
+use Nelmio\SecurityBundle\ContentSecurityPolicy\DirectiveSetBuilderInterface;
+use Nelmio\SecurityBundle\ContentSecurityPolicy\LegacyDirectiveSetBuilder;
 use Nelmio\SecurityBundle\ContentSecurityPolicy\NonceGeneratorInterface;
 use Nelmio\SecurityBundle\ContentSecurityPolicy\ShaComputerInterface;
 use Symfony\Component\HttpFoundation\Request;
@@ -24,8 +26,8 @@ use Symfony\Component\HttpKernel\KernelEvents;
 
 final class ContentSecurityPolicyListener extends AbstractContentTypeRestrictableListener
 {
-    private DirectiveSet $report;
-    private DirectiveSet $enforce;
+    private DirectiveSetBuilderInterface $reportDirectiveSetBuilder;
+    private DirectiveSetBuilderInterface $enforceDirectiveSetBuilder;
     private bool $compatHeaders;
 
     /**
@@ -45,12 +47,14 @@ final class ContentSecurityPolicyListener extends AbstractContentTypeRestrictabl
     private ?RequestMatcherInterface $requestMatcher;
 
     /**
-     * @param list<string> $hosts
-     * @param list<string> $contentTypes
+     * @param DirectiveSetBuilderInterface|DirectiveSet $reportDirectiveSetBuilder
+     * @param DirectiveSetBuilderInterface|DirectiveSet $enforceDirectiveSetBuilder
+     * @param list<string>                              $hosts
+     * @param list<string>                              $contentTypes
      */
     public function __construct(
-        DirectiveSet $report,
-        DirectiveSet $enforce,
+        $reportDirectiveSetBuilder,
+        $enforceDirectiveSetBuilder,
         NonceGeneratorInterface $nonceGenerator,
         ShaComputerInterface $shaComputer,
         bool $compatHeaders = true,
@@ -59,8 +63,8 @@ final class ContentSecurityPolicyListener extends AbstractContentTypeRestrictabl
         ?RequestMatcherInterface $requestMatcher = null
     ) {
         parent::__construct($contentTypes);
-        $this->report = $report;
-        $this->enforce = $enforce;
+        $this->reportDirectiveSetBuilder = $this->ensureDirectiveSetBuilder($reportDirectiveSetBuilder);
+        $this->enforceDirectiveSetBuilder = $this->ensureDirectiveSetBuilder($enforceDirectiveSetBuilder);
         $this->compatHeaders = $compatHeaders;
         $this->hosts = $hosts;
         $this->nonceGenerator = $nonceGenerator;
@@ -110,14 +114,20 @@ final class ContentSecurityPolicyListener extends AbstractContentTypeRestrictabl
         $this->sha['style-src'][] = $this->shaComputer->computeForStyle($html);
     }
 
+    /**
+     * @deprecated Use `nelmio_security.directive_set_builder.report` instead.
+     */
     public function getReport(): DirectiveSet
     {
-        return $this->report;
+        return $this->reportDirectiveSetBuilder->buildDirectiveSet();
     }
 
+    /**
+     * @deprecated Use `nelmio_security.directive_set_builder.enforce` instead.
+     */
     public function getEnforcement(): DirectiveSet
     {
-        return $this->enforce;
+        return $this->enforceDirectiveSetBuilder->buildDirectiveSet();
     }
 
     public function getNonce(string $usage): string
@@ -169,10 +179,10 @@ final class ContentSecurityPolicyListener extends AbstractContentTypeRestrictabl
             }
 
             if (!$response->headers->has('Content-Security-Policy-Report-Only')) {
-                $response->headers->add($this->buildHeaders($request, $this->report, true, $this->compatHeaders, $signatures));
+                $response->headers->add($this->buildHeaders($request, $this->reportDirectiveSetBuilder->buildDirectiveSet(), true, $this->compatHeaders, $signatures));
             }
             if (!$response->headers->has('Content-Security-Policy')) {
-                $response->headers->add($this->buildHeaders($request, $this->enforce, false, $this->compatHeaders, $signatures));
+                $response->headers->add($this->buildHeaders($request, $this->enforceDirectiveSetBuilder->buildDirectiveSet(), false, $this->compatHeaders, $signatures));
             }
         }
 
@@ -232,5 +242,32 @@ final class ContentSecurityPolicyListener extends AbstractContentTypeRestrictabl
         }
 
         return $headers;
+    }
+
+    /**
+     * @param DirectiveSetBuilderInterface|DirectiveSet $builderOrDirectiveSet
+     */
+    private function ensureDirectiveSetBuilder($builderOrDirectiveSet): DirectiveSetBuilderInterface
+    {
+        if ($builderOrDirectiveSet instanceof DirectiveSetBuilderInterface) {
+            return $builderOrDirectiveSet;
+        }
+
+        if ($builderOrDirectiveSet instanceof DirectiveSet) {
+            trigger_deprecation(
+                'nelmio/security-bundle',
+                '3.3',
+                sprintf(
+                    'Passing %s directly to the %s constructor is deprecated and will be removed in 4.0. Pass a %s instead.',
+                    DirectiveSet::class,
+                    self::class,
+                    DirectiveSetBuilderInterface::class
+                )
+            );
+
+            return new LegacyDirectiveSetBuilder($builderOrDirectiveSet);
+        }
+
+        throw new \InvalidArgumentException(sprintf('The %s constructor %s expects a or %s.', self::class, DirectiveSetBuilderInterface::class, DirectiveSet::class));
     }
 }

--- a/tests/Twig/IntegrationTest.php
+++ b/tests/Twig/IntegrationTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Nelmio\SecurityBundle\Tests\Twig;
 
 use Nelmio\SecurityBundle\ContentSecurityPolicy\DirectiveSet;
+use Nelmio\SecurityBundle\ContentSecurityPolicy\DirectiveSetBuilderInterface;
 use Nelmio\SecurityBundle\ContentSecurityPolicy\NonceGeneratorInterface;
 use Nelmio\SecurityBundle\ContentSecurityPolicy\PolicyManager;
 use Nelmio\SecurityBundle\ContentSecurityPolicy\ShaComputerInterface;
@@ -45,8 +46,8 @@ class IntegrationTest extends TestCase
         $policyManager = new PolicyManager();
 
         $listener = new ContentSecurityPolicyListener(
-            new DirectiveSet($policyManager),
-            new DirectiveSet($policyManager),
+            $this->createDirectiveSetBuilderMock(new DirectiveSet($policyManager)),
+            $this->createDirectiveSetBuilderMock(new DirectiveSet($policyManager)),
             $this->createStub(NonceGeneratorInterface::class),
             $shaComputer
         );
@@ -94,8 +95,8 @@ class IntegrationTest extends TestCase
         $policyManager = new PolicyManager();
 
         $listener = new ContentSecurityPolicyListener(
-            new DirectiveSet($policyManager),
-            new DirectiveSet($policyManager),
+            $this->createDirectiveSetBuilderMock(new DirectiveSet($policyManager)),
+            $this->createDirectiveSetBuilderMock(new DirectiveSet($policyManager)),
             $this->createStub(NonceGeneratorInterface::class),
             $shaComputer
         );
@@ -126,5 +127,13 @@ class IntegrationTest extends TestCase
         }, null, ContentSecurityPolicyListener::class);
 
         $this->assertSame(['script-src' => ['sha-script'], 'style-src' => ['sha-style']], $getSha($listener));
+    }
+
+    private function createDirectiveSetBuilderMock(DirectiveSet $directiveSet): DirectiveSetBuilderInterface
+    {
+        $mock = $this->createMock(DirectiveSetBuilderInterface::class);
+        $mock->method('buildDirectiveSet')->willReturn($directiveSet);
+
+        return $mock;
     }
 }


### PR DESCRIPTION
This PR introduces the `DirectiveSetBuilderInterface` and the default implementation` ConfigurationDirectiveSetBuilder` proposed in #347, to allow for runtime modification of the CSP directive sets. The major changes are:

- Introduction of `DirectiveSetBuilderInterface` and `ConfigurationDirectiveSetBuilder`;
- The `ContentSecurityPolicyListener` constructor now takes `DirectiveSetBuilderInterface` instead of the directive sets directly;
- Changes to `NelmioSecurityExtension` to provide the configuration to the `ConfigurationDirectiveSetBuilder`s, which in turn are injected into `ContentSecurityPolicyListener` (instead of the directive sets).

This adds a layer between the configuration (and the directive sets built from it) and `ContentSecurityPolicyListener`. This layer provides an integration point for application code to modify the directive sets based on the request (e.g., in a controller or a kernel event listener).