### PR TITLE
Fix DI Extension class deprecation with Symfony 7.1

### DIFF
--- a/src/DependencyInjection/NelmioSecurityExtension.php
+++ b/src/DependencyInjection/NelmioSecurityExtension.php
@@ -18,9 +18,9 @@ use Symfony\Component\Config\Definition\Processor;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
 use Symfony\Component\DependencyInjection\Reference;
-use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 final class NelmioSecurityExtension extends Extension
 {


### PR DESCRIPTION
The "Symfony\Component\HttpKernel\DependencyInjection\Extension" class is considered internal since Symfony 7.1, to be deprecated in 8.1; use Symfony\Component\DependencyInjection\Extension\Extension instead. It may change without further notice. You should not use it from "Presta\SitemapBundle\DependencyInjection\PrestaSitemapExtension".