### PR TITLE
Restore deprecated XSS default configuration values

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -333,9 +333,9 @@ final class Configuration implements ConfigurationInterface
         $node->setDeprecated('nelmio/security-bundle', '3.4.0', 'The "%node%" option is deprecated, use Content Security Policy without allowing "unsafe-inline" scripts instead.');
         $node
             ->children()
-                ->booleanNode('enabled')->end()
-                ->booleanNode('mode_block')->end()
-                ->scalarNode('report_uri')->end()
+                ->booleanNode('enabled')->defaultFalse()->end()
+                ->booleanNode('mode_block')->defaultFalse()->end()
+                ->scalarNode('report_uri')->defaultNull()->end()
             ->end();
 
         return $node;


### PR DESCRIPTION
The removal of the default configuration values during [the deprecation of this feature](https://github.com/nelmio/NelmioSecurityBundle/pull/342/files#diff-ebe00144d6cecb5ca8a2860883e01147f42bbed2b12a3a7f44915908a4829faa) is not backward-compatible and breaks container building for application that do not explicitly set `report_uri`.

Since the feature is expected to continue to work during the deprecation period I think it is safest to restore the defaults.