### PR TITLE
Deprecate the default signed cookie algorithm

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -253,7 +253,7 @@ final class Configuration implements ConfigurationInterface
                     ->defaultValue(['*'])
                 ->end()
                 ->scalarNode('secret')->defaultValue('%kernel.secret%')->end()
-                ->scalarNode('hash_algo')->defaultValue('sha256')->end()
+                ->scalarNode('hash_algo')->end()
             ->end();
 
         return $node;

--- a/src/DependencyInjection/NelmioSecurityExtension.php
+++ b/src/DependencyInjection/NelmioSecurityExtension.php
@@ -35,7 +35,13 @@ final class NelmioSecurityExtension extends Extension
             $loader->load('signed_cookie.php');
             $container->setParameter('nelmio_security.signed_cookie.names', $config['signed_cookie']['names']);
             $container->setParameter('nelmio_security.signer.secret', $config['signed_cookie']['secret']);
-            $container->setParameter('nelmio_security.signer.hash_algo', $config['signed_cookie']['hash_algo']);
+
+            if (isset($config['signed_cookie']['hash_algo'])) {
+                $container->setParameter('nelmio_security.signer.hash_algo', $config['signed_cookie']['hash_algo']);
+            } else {
+                trigger_deprecation('nelmio/security-bundle', '3.4.0', 'The default value for `signed_cookie.hash_algo` is deprecated and will change in 4.0. You should configure an algorithm explicitly.');
+                $container->setParameter('nelmio_security.signer.hash_algo', 'sha256');
+            }
         }
 
         if (isset($config['clickjacking']) && [] !== $config['clickjacking']) {


### PR DESCRIPTION
Deprecate the default value for the `signed_cookie.hash_algo` configuration value (currently "sha256") in preparation for a change in 4.0.

Relates to #324.