### PR TITLE
Add support for the `report-to` directive

### DIFF
--- a/src/ContentSecurityPolicy/DirectiveSet.php
+++ b/src/ContentSecurityPolicy/DirectiveSet.php
@@ -29,6 +29,8 @@ final class DirectiveSet
     public const TYPE_NO_VALUE = 'no-value';
     /** @internal */
     public const TYPE_SRC_LIST = 'source-list';
+    /** @internal */
+    public const TYPE_REPORTING_GROUP = 'reporting-group';
 
     /**
      * @var array<string, string>
@@ -54,6 +56,7 @@ final class DirectiveSet
         'report-uri' => self::TYPE_URI_REFERENCE,
         'worker-src' => self::TYPE_SRC_LIST,
         'prefetch-src' => self::TYPE_SRC_LIST,
+        'report-to' => self::TYPE_REPORTING_GROUP,
     ];
 
     /**

--- a/src/ContentSecurityPolicy/PolicyManager.php
+++ b/src/ContentSecurityPolicy/PolicyManager.php
@@ -131,6 +131,7 @@ final class PolicyManager
                 'reflected-xss',
                 'worker-src',
                 'prefetch-src',
+                'report-to',
             ]);
         }
 

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -197,7 +197,7 @@ final class Configuration implements ConfigurationInterface
                             ->then(static function (string $value): array { return [$value]; })
                         ->end()
                     ->end();
-            } elseif (DirectiveSet::TYPE_URI_REFERENCE === $type) {
+            } elseif (\in_array($type, [DirectiveSet::TYPE_URI_REFERENCE, DirectiveSet::TYPE_REPORTING_GROUP], true)) {
                 $children->scalarNode($name)
                     ->end();
             } else {

--- a/src/Resources/doc/index.rst
+++ b/src/Resources/doc/index.rst
@@ -188,7 +188,8 @@ scripts or ``eval()`` you can use ``'unsafe-inline'`` and ``'unsafe-eval'``.
 
 Apart from content types, the policy also accepts ``report-uri`` which should be
 a URI where a browser can POST a `JSON payload`_ to whenever a policy directive
-is violated.
+is violated. As of v3.5, a ``report-to`` directive can be included as well to configure a
+reporting endpoint (see `Reporting API`_), which is intended to replace the deprecated ``report-uri`` directive.
 
 An optional ``content_types`` key lets you restrict the Content Security Policy
 headers only on some HTTP response given their content type.
@@ -961,3 +962,4 @@ For better security of your site please use ``no-referrer``, ``same-origin``,
 .. _`a non-standard nosniff header from Microsoft`: http://msdn.microsoft.com/en-us/library/ie/gg622941.aspx
 .. _`a non-standard X-XSS-Protection header from Microsoft`: http://blogs.msdn.com/b/ieinternals/archive/2011/01/31/controlling-the-internet-explorer-xss-filter-with-the-x-xss-protection-http-header.aspx
 .. _`referrer policies`: https://www.w3.org/TR/referrer-policy/#referrer-policies
+.. _`Reporting API`: https://www.w3.org/TR/reporting-1/

--- a/tests/ContentSecurityPolicy/DirectiveSetTest.php
+++ b/tests/ContentSecurityPolicy/DirectiveSetTest.php
@@ -65,7 +65,8 @@ class DirectiveSetTest extends TestCase
                 'style-src style.example.org \'self\'; '.
                 'upgrade-insecure-requests; '.
                 'report-uri http://report-uri; '.
-                'worker-src worker.example.com \'self\'',
+                'worker-src worker.example.com \'self\'; '.
+                'report-to csp-endpoint',
                 self::UA_CHROME,
                 [
                     'default-src' => ['example.org', "'self'"],
@@ -80,6 +81,7 @@ class DirectiveSetTest extends TestCase
                     'connect-src' => ['connect.example.org', "'self'"],
                     'worker-src' => ['worker.example.com', "'self'"],
                     'report-uri' => ['http://report-uri'],
+                    'report-to' => 'csp-endpoint',
                     'base-uri' => ['base-uri.example.org', "'self'"],
                     'child-src' => ['child-src.example.org', "'self'"],
                     'form-action' => ['form-action.example.org', "'self'"],
@@ -106,7 +108,8 @@ class DirectiveSetTest extends TestCase
                 'style-src style.example.org \'self\'; '.
                 'upgrade-insecure-requests; '.
                 'report-uri http://report-uri; '.
-                'worker-src worker.example.com \'self\'',
+                'worker-src worker.example.com \'self\'; '.
+                'report-to csp-endpoint',
                 self::UA_FIREFOX,
                 [
                     'default-src' => ['example.org', "'self'"],
@@ -121,6 +124,7 @@ class DirectiveSetTest extends TestCase
                     'connect-src' => ['connect.example.org', "'self'"],
                     'worker-src' => ['worker.example.com', "'self'"],
                     'report-uri' => ['http://report-uri'],
+                    'report-to' => 'csp-endpoint',
                     'base-uri' => ['base-uri.example.org', "'self'"],
                     'child-src' => ['child-src.example.org', "'self'"],
                     'form-action' => ['form-action.example.org', "'self'"],
@@ -149,7 +153,8 @@ class DirectiveSetTest extends TestCase
                 'style-src style.example.org \'self\'; '.
                 'upgrade-insecure-requests; '.
                 'report-uri http://report-uri; '.
-                'worker-src worker.example.com \'self\'',
+                'worker-src worker.example.com \'self\'; '.
+                'report-to csp-endpoint',
                 self::UA_IE,
                 [
                     'default-src' => ['example.org', "'self'"],
@@ -163,6 +168,7 @@ class DirectiveSetTest extends TestCase
                     'connect-src' => ['connect.example.org', "'self'"],
                     'worker-src' => ['worker.example.com', "'self'"],
                     'report-uri' => ['http://report-uri'],
+                    'report-to' => 'csp-endpoint',
                     'base-uri' => ['base-uri.example.org', "'self'"],
                     'child-src' => ['child-src.example.org', "'self'"],
                     'form-action' => ['form-action.example.org', "'self'"],
@@ -192,7 +198,8 @@ class DirectiveSetTest extends TestCase
                 'style-src style.example.org \'self\'; '.
                 'upgrade-insecure-requests; '.
                 'report-uri http://report-uri; '.
-                'worker-src worker.example.com \'self\'',
+                'worker-src worker.example.com \'self\'; '.
+                'report-to csp-endpoint',
                 self::UA_OPERA,
                 [
                     'default-src' => ['example.org', "'self'"],
@@ -207,6 +214,7 @@ class DirectiveSetTest extends TestCase
                     'connect-src' => ['connect.example.org', "'self'"],
                     'worker-src' => ['worker.example.com', "'self'"],
                     'report-uri' => ['http://report-uri'],
+                    'report-to' => 'csp-endpoint',
                     'base-uri' => ['base-uri.example.org', "'self'"],
                     'child-src' => ['child-src.example.org', "'self'"],
                     'form-action' => ['form-action.example.org', "'self'"],
@@ -241,6 +249,7 @@ class DirectiveSetTest extends TestCase
                     'connect-src' => ['connect.example.org', "'self'"],
                     'worker-src' => ['worker.example.com', "'self'"],
                     'report-uri' => ['http://report-uri'],
+                    'report-to' => 'csp-endpoint',
                     'base-uri' => ['base-uri.example.org', "'self'"],
                     'child-src' => ['child-src.example.org', "'self'"],
                     'form-action' => ['form-action.example.org', "'self'"],
@@ -267,7 +276,8 @@ class DirectiveSetTest extends TestCase
                 'script-src script.example.org \'self\'; '.
                 'style-src style.example.org \'self\'; '.
                 'report-uri http://report-uri; '.
-                'worker-src worker.example.com \'self\'',
+                'worker-src worker.example.com \'self\'; '.
+                'report-to csp-endpoint',
                 self::UA_CHROME,
                 [
                     'default-src' => ['example.org', "'self'"],
@@ -281,6 +291,7 @@ class DirectiveSetTest extends TestCase
                     'connect-src' => ['connect.example.org', "'self'"],
                     'worker-src' => ['worker.example.com', "'self'"],
                     'report-uri' => ['http://report-uri'],
+                    'report-to' => 'csp-endpoint',
                     'base-uri' => ['base-uri.example.org', "'self'"],
                     'child-src' => ['child-src.example.org', "'self'"],
                     'form-action' => ['form-action.example.org', "'self'"],


### PR DESCRIPTION
This PR extends `DirectiveSet` with the [`report-to` directive](https://w3c.github.io/webappsec-csp/#directive-report-to). It is part of CSP Level 3 and intended to replace the deprecated [`report-uri` directive](https://w3c.github.io/webappsec-csp/#directive-report-uri).

The `report-to` directive works with reporting endpoints (from [Reporting](https://www.w3.org/TR/reporting-1/)). The endpoints need to be configured through another header (`Reporting-Endpoints`, [previously `Report-To`](https://www.w3.org/TR/2018/WD-reporting-1-20180925/)). This PR only adds the CSP directive; this enables users to migrate to the new reporting API if they provide the endpoints (via a `Reporting-Endpoints` header) themselves.

I did not deprecate the `report-uri` directive because browsers ignore it when a `report-to` directive is present and the browser supports it. Not all (major) browsers support this directive currently, so `report-uri` is still usefull for reporting in all browsers.

Fixes  #341 