### PR TITLE
Twig: fix version check by removing additional 0

### DIFF
--- a/src/Twig/Version.php
+++ b/src/Twig/Version.php
@@ -20,6 +20,6 @@ final class Version
 {
     public static function needsNodeTag(): bool
     {
-        return \Twig\Environment::VERSION_ID < 301200;
+        return \Twig\Environment::VERSION_ID < 31200;
     }
 }


### PR DESCRIPTION
Twig versions are defined like `public const VERSION_ID = 31500;` there is no 0 between major and minor