### PR TITLE
Fix BC break introduced in 3.5

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -71,3 +71,19 @@ parameters:
 			"""
 			count: 1
 			path: tests/Listener/XssProtectionListenerTest.php
+
+		-
+			message: """
+				#^Call to deprecated method getEnforcement\\(\\) of class Nelmio\\\\SecurityBundle\\\\EventListener\\\\ContentSecurityPolicyListener\\:
+				Use `nelmio_security\\.directive_set_builder\\.enforce` instead\\.$#
+			"""
+			count: 1
+			path: tests/Listener/ContentSecurityPolicyListenerTest.php
+
+		-
+			message: """
+				#^Call to deprecated method getReport\\(\\) of class Nelmio\\\\SecurityBundle\\\\EventListener\\\\ContentSecurityPolicyListener\\:
+				Use `nelmio_security\\.directive_set_builder\\.report` instead\\.$#
+			"""
+			count: 1
+			path: tests/Listener/ContentSecurityPolicyListenerTest.php

--- a/src/ContentSecurityPolicy/ConfigurationDirectiveSetBuilder.php
+++ b/src/ContentSecurityPolicy/ConfigurationDirectiveSetBuilder.php
@@ -15,20 +15,7 @@ namespace Nelmio\SecurityBundle\ContentSecurityPolicy;
 
 class ConfigurationDirectiveSetBuilder implements DirectiveSetBuilderInterface
 {
-    private PolicyManager $policyManager;
-
-    /**
-     * @phpstan-var array{
-     *       enforce?: array<string, mixed>,
-     *       report?: array<string, mixed>,
-     *   } $config
-     */
-    private array $config;
-
-    /**
-     * @phpstan-var 'enforce'|'report' $kind
-     */
-    private string $kind;
+    private DirectiveSet $directiveSet;
 
     /**
      * @phpstan-param array{
@@ -39,14 +26,12 @@ class ConfigurationDirectiveSetBuilder implements DirectiveSetBuilderInterface
      */
     public function __construct(PolicyManager $policyManager, array $config, string $kind)
     {
-        $this->policyManager = $policyManager;
-        $this->config = $config;
-        $this->kind = $kind;
+        $this->directiveSet = DirectiveSet::fromConfig($policyManager, $config, $kind);
     }
 
     public function buildDirectiveSet(): DirectiveSet
     {
-        return DirectiveSet::fromConfig($this->policyManager, $this->config, $this->kind);
+        return $this->directiveSet;
     }
 
     /**


### PR DESCRIPTION
The BC break was caused by the changes to `ContentSecurityPolicyListener::getReport` and `ContentSecurityPolicyListener::getEnforcement`. In 3.5, these methods return a new DirectiveSet instead of the same instance as in previous versions. Code that used these methods to modify the DirectiveSets no longer saw these modifications reflected in the CSP header.

This is fixed by making `ConfigurationDirectiveSetBuilder` (the default builder) always return the same DirectiveSet by building it once rather than on each call.

Fixes #369.