### PR TITLE
Add Cross-Origin Policy feature with configurable headers (COEP, COOP, CORP)

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -69,6 +69,8 @@ final class Configuration implements ConfigurationInterface
                 ->append($this->addReferrerPolicyNode())
 
                 ->append($this->addPermissionsPolicyNode())
+
+                ->append($this->addCrossOriginIsolationNodes())
             ->end()
         ->end();
 
@@ -391,6 +393,47 @@ final class Configuration implements ConfigurationInterface
             ->children()
                 ->scalarNode('cookie_name')->defaultValue('auth')->end()
                 ->booleanNode('unsecured_logout')->defaultFalse()->end()
+            ->end();
+
+        return $node;
+    }
+
+    private function addCrossOriginIsolationNodes(): ArrayNodeDefinition
+    {
+        $node = new ArrayNodeDefinition('cross_origin_isolation');
+        $node
+            ->canBeEnabled()
+            ->fixXmlConfig('path')
+            ->children()
+                ->arrayNode('paths')
+                    ->normalizeKeys(false)
+                    ->useAttributeAsKey('pattern')
+                    ->arrayPrototype()
+                        ->children()
+                            ->enumNode('coep')
+                                ->values(['unsafe-none', 'require-corp', 'credentialless'])
+                                ->info('Cross-Origin-Embedder-Policy (COEP) header value')
+                            ->end()
+                            ->enumNode('coop')
+                                ->values(['unsafe-none', 'same-origin-allow-popups', 'same-origin', 'noopener-allow-popups'])
+                                ->info('Cross-Origin-Opener-Policy (COOP) header value')
+                            ->end()
+                            ->enumNode('corp')
+                                ->values(['same-site', 'same-origin', 'cross-origin'])
+                                ->info('Cross-Origin-Resource-Policy (CORP) header value')
+                            ->end()
+                            ->booleanNode('report_only')
+                                ->defaultFalse()
+                                ->info('Use Report-Only headers instead of enforcing (applies to COEP and COOP only)')
+                            ->end()
+                            ->scalarNode('report_to')
+                                ->defaultNull()
+                                ->info('Reporting endpoint name for violations (requires Reporting API configuration, applies to COEP and COOP only)')
+                            ->end()
+                        ->end()
+                    ->end()
+                    ->requiresAtLeastOneElement()
+                ->end()
             ->end();
 
         return $node;

--- a/src/DependencyInjection/NelmioSecurityExtension.php
+++ b/src/DependencyInjection/NelmioSecurityExtension.php
@@ -181,6 +181,12 @@ final class NelmioSecurityExtension extends Extension
             $loader->load('permissions_policy.php');
             $container->setParameter('nelmio_security.permissions_policy.policies', $config['permissions_policy']['policies']);
         }
+
+        if ($this->isConfigEnabled($container, $config['cross_origin_isolation'])) {
+            $loader->load('cross_origin_isolation.php');
+            $container->getDefinition('nelmio_security.cross_origin_isolation_listener')
+                ->replaceArgument(0, $config['cross_origin_isolation']['paths']);
+        }
     }
 
     /**

--- a/src/EventListener/CrossOriginPolicyListener.php
+++ b/src/EventListener/CrossOriginPolicyListener.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Nelmio SecurityBundle.
+ *
+ * (c) Nelmio <hello@nelm.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\SecurityBundle\EventListener;
+
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
+
+/**
+ * @author Florent Morselli <florent.morselli@spomky-labs.com>
+ *
+ * @internal
+ */
+final class CrossOriginPolicyListener
+{
+    /**
+     * @var array<string, array{coep?: string, coop?: string, corp?: string, report_only?: bool, report_to?: string|null}>
+     */
+    private array $paths;
+
+    /**
+     * @param array<string, array{coep?: string, coop?: string, corp?: string, report_only?: bool, report_to?: string|null}> $paths
+     */
+    public function __construct(array $paths)
+    {
+        $this->paths = $paths;
+    }
+
+    public function onKernelResponse(ResponseEvent $e): void
+    {
+        if (!$e->isMainRequest()) {
+            return;
+        }
+
+        $response = $e->getResponse();
+
+        if ($response->isRedirection()) {
+            return;
+        }
+
+        $request = $e->getRequest();
+
+        $currentPath = '' === $request->getRequestUri() ? '/' : $request->getRequestUri();
+
+        foreach ($this->paths as $path => $options) {
+            if (1 === preg_match('{'.$path.'}i', $currentPath)) {
+                $reportOnly = $options['report_only'] ?? false;
+                $reportTo = $options['report_to'] ?? null;
+
+                // Handle COEP
+                if (isset($options['coep'])) {
+                    $coepValue = $options['coep'];
+                    if (null !== $reportTo) {
+                        $coepValue .= '; report-to="'.$reportTo.'"';
+                    }
+                    $coepHeader = $reportOnly ? 'Cross-Origin-Embedder-Policy-Report-Only' : 'Cross-Origin-Embedder-Policy';
+                    $response->headers->set($coepHeader, $coepValue);
+                }
+
+                // Handle COOP
+                if (isset($options['coop'])) {
+                    $coopValue = $options['coop'];
+                    if (null !== $reportTo) {
+                        $coopValue .= '; report-to="'.$reportTo.'"';
+                    }
+                    $coopHeader = $reportOnly ? 'Cross-Origin-Opener-Policy-Report-Only' : 'Cross-Origin-Opener-Policy';
+                    $response->headers->set($coopHeader, $coopValue);
+                }
+
+                // Handle CORP (no report-only or report-to)
+                if (isset($options['corp'])) {
+                    $response->headers->set('Cross-Origin-Resource-Policy', $options['corp']);
+                }
+
+                return;
+            }
+        }
+    }
+}

--- a/src/Resources/config/cross_origin_isolation.php
+++ b/src/Resources/config/cross_origin_isolation.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Nelmio SecurityBundle.
+ *
+ * (c) Nelmio <hello@nelm.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Nelmio\SecurityBundle\EventListener\CrossOriginPolicyListener;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+use function Symfony\Component\DependencyInjection\Loader\Configurator\abstract_arg;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $containerConfigurator->services()
+
+        ->set('nelmio_security.cross_origin_isolation_listener', CrossOriginPolicyListener::class)
+            ->args([
+                abstract_arg('cross-origin isolation paths'),
+            ])
+            ->tag('kernel.event_listener', [
+                'event' => 'kernel.response',
+                'method' => 'onKernelResponse',
+            ]);
+};

--- a/tests/App/config/config.yaml
+++ b/tests/App/config/config.yaml
@@ -21,6 +21,36 @@ nelmio_security:
       - 'no-referrer'
       - 'strict-origin-when-cross-origin'
 
+  cross_origin_isolation:
+    enabled: true
+    paths:
+      '^/admin':
+        coep: require-corp
+        coop: same-origin
+        corp: same-origin
+      '^/api':
+        coep: unsafe-none
+        corp: cross-origin
+      '^/articles':
+        coop: same-origin-allow-popups
+      '^/test-report-only':
+        coep: require-corp
+        coop: same-origin
+        report_only: true
+      '^/test-report-to':
+        coep: require-corp
+        coop: same-origin
+        report_to: coi-endpoint
+      '^/test-report-combined':
+        coep: require-corp
+        coop: same-origin
+        report_only: true
+        report_to: coi-endpoint
+      '^/.*':
+        coep: credentialless
+        coop: same-origin
+        corp: cross-origin
+
   csp:
     enabled: true
     hosts: [ ]

--- a/tests/App/config/routes.yaml
+++ b/tests/App/config/routes.yaml
@@ -19,3 +19,57 @@ csp_report:
   path: /csp/report
   methods: [POST]
   defaults: { _controller: nelmio_security.csp_reporter_controller::indexAction }
+
+# Routes for testing cross-origin isolation
+admin:
+  path: /admin/{path}
+  requirements:
+    path: ".*"
+  defaults:
+    _controller: Symfony\Bundle\FrameworkBundle\Controller\TemplateController
+    template: 'homepage.html.twig'
+    path: ''
+
+api:
+  path: /api/{path}
+  requirements:
+    path: ".*"
+  defaults:
+    _controller: Symfony\Bundle\FrameworkBundle\Controller\TemplateController
+    template: 'homepage.html.twig'
+    path: ''
+
+articles:
+  path: /articles/{path}
+  requirements:
+    path: ".*"
+  defaults:
+    _controller: Symfony\Bundle\FrameworkBundle\Controller\TemplateController
+    template: 'homepage.html.twig'
+    path: ''
+
+other:
+  path: /other/{path}
+  requirements:
+    path: ".+"
+  defaults:
+    _controller: Symfony\Bundle\FrameworkBundle\Controller\TemplateController
+    template: 'homepage.html.twig'
+
+test_report_only:
+  path: /test-report-only
+  defaults:
+    _controller: Symfony\Bundle\FrameworkBundle\Controller\TemplateController
+    template: 'homepage.html.twig'
+
+test_report_to:
+  path: /test-report-to
+  defaults:
+    _controller: Symfony\Bundle\FrameworkBundle\Controller\TemplateController
+    template: 'homepage.html.twig'
+
+test_report_combined:
+  path: /test-report-combined
+  defaults:
+    _controller: Symfony\Bundle\FrameworkBundle\Controller\TemplateController
+    template: 'homepage.html.twig'

--- a/tests/Functional/CrossOriginPolicyTest.php
+++ b/tests/Functional/CrossOriginPolicyTest.php
@@ -1,0 +1,157 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Nelmio SecurityBundle.
+ *
+ * (c) Nelmio <hello@nelm.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\SecurityBundle\Tests\Functional;
+
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+final class CrossOriginPolicyTest extends WebTestCase
+{
+    /**
+     * @dataProvider providePathsAndExpectedHeaders
+     */
+    public function testPathSpecificHeaders(string $path, ?string $expectedCoep, ?string $expectedCoop, ?string $expectedCorp): void
+    {
+        $client = static::createClient();
+
+        $client->request('GET', $path);
+
+        $response = $client->getResponse();
+
+        if (null !== $expectedCoep) {
+            $this->assertResponseHeaderSame('cross-origin-embedder-policy', $expectedCoep);
+        } else {
+            $this->assertFalse($response->headers->has('cross-origin-embedder-policy'));
+        }
+
+        if (null !== $expectedCoop) {
+            $this->assertResponseHeaderSame('cross-origin-opener-policy', $expectedCoop);
+        } else {
+            $this->assertFalse($response->headers->has('cross-origin-opener-policy'));
+        }
+
+        if (null !== $expectedCorp) {
+            $this->assertResponseHeaderSame('cross-origin-resource-policy', $expectedCorp);
+        } else {
+            $this->assertFalse($response->headers->has('cross-origin-resource-policy'));
+        }
+    }
+
+    /**
+     * @return iterable<string, array{string, string|null, string|null, string|null}>
+     */
+    public static function providePathsAndExpectedHeaders(): iterable
+    {
+        // Test /admin path - most specific, should match first
+        yield 'admin path' => [
+            '/admin',
+            'require-corp',
+            'same-origin',
+            'same-origin',
+        ];
+
+        yield 'admin subpath' => [
+            '/admin/users',
+            'require-corp',
+            'same-origin',
+            'same-origin',
+        ];
+
+        // Test /api path - only coep and corp defined
+        yield 'api path' => [
+            '/api',
+            'unsafe-none',
+            null,
+            'cross-origin',
+        ];
+
+        yield 'api subpath' => [
+            '/api/v1/users',
+            'unsafe-none',
+            null,
+            'cross-origin',
+        ];
+
+        // Test /articles path - only coop defined
+        yield 'articles path' => [
+            '/articles',
+            null,
+            'same-origin-allow-popups',
+            null,
+        ];
+
+        yield 'articles subpath' => [
+            '/articles/123',
+            null,
+            'same-origin-allow-popups',
+            null,
+        ];
+
+        // Test default path - should match any other path
+        yield 'root path' => [
+            '/',
+            'credentialless',
+            'same-origin',
+            'cross-origin',
+        ];
+
+        yield 'other path' => [
+            '/other/path',
+            'credentialless',
+            'same-origin',
+            'cross-origin',
+        ];
+    }
+
+    public function testReportOnlyMode(): void
+    {
+        $client = static::createClient();
+
+        // Test that report-only headers are used instead
+        $client->request('GET', '/test-report-only');
+
+        $response = $client->getResponse();
+
+        // Should use Report-Only headers
+        $this->assertResponseHeaderSame('cross-origin-embedder-policy-report-only', 'require-corp');
+        $this->assertResponseHeaderSame('cross-origin-opener-policy-report-only', 'same-origin');
+        $this->assertFalse($response->headers->has('cross-origin-embedder-policy'));
+        $this->assertFalse($response->headers->has('cross-origin-opener-policy'));
+    }
+
+    public function testReportToEndpoint(): void
+    {
+        $client = static::createClient();
+
+        // Test that report-to parameter is added
+        $client->request('GET', '/test-report-to');
+
+        $response = $client->getResponse();
+
+        $this->assertResponseHeaderSame('cross-origin-embedder-policy', 'require-corp; report-to="coi-endpoint"');
+        $this->assertResponseHeaderSame('cross-origin-opener-policy', 'same-origin; report-to="coi-endpoint"');
+    }
+
+    public function testReportOnlyWithReportTo(): void
+    {
+        $client = static::createClient();
+
+        // Test combination of report-only + report-to
+        $client->request('GET', '/test-report-combined');
+
+        $response = $client->getResponse();
+
+        $this->assertResponseHeaderSame('cross-origin-embedder-policy-report-only', 'require-corp; report-to="coi-endpoint"');
+        $this->assertResponseHeaderSame('cross-origin-opener-policy-report-only', 'same-origin; report-to="coi-endpoint"');
+    }
+}


### PR DESCRIPTION
Hi,

This is a first attempt at addressing #371.
Feedback is very welcome.
Pease let me know if anything should be adjusted or improved.

EDIT: Here's how to use the Cross-Origin Isolation feature added in this PR:

## Basic Configuration

Add to config/packages/nelmio_security.yaml:

```yaml
  nelmio_security:
      cross_origin_isolation:
          enabled: true
          paths:
              '^/.*':
                  coep: require-corp      # Cross-Origin-Embedder-Policy
                  coop: same-origin       # Cross-Origin-Opener-Policy
                  corp: same-origin       # Cross-Origin-Resource-Policy
```
## Available Values

* COEP: `unsafe-none`, `require-corp`, `credentialless`
* COOP: `unsafe-none`, `same-origin`, `same-origin-allow-popups`, `noopener-allow-popups`
* CORP: `same-site`, `same-origin`, `cross-origin`

 Path-Based Configuration

```yaml
  nelmio_security:
      cross_origin_isolation:
          enabled: true
          paths:
              '^/admin':
                  coep: require-corp
                  coop: same-origin
                  corp: same-origin
              '^/api':
                  coep: unsafe-none
                  corp: cross-origin
```

Report-Only Mode (for testing)

```yaml
  paths:
      '^/.*':
          coep:
              value: require-corp
              report_only: true
          coop:
              value: same-origin
              report_only: true
```

## Notes

* Using `coep: require-corp` + `coop: same-origin` enables cross-origin isolation (required for `SharedArrayBuffer`)
* Start with Report-Only mode to test before enforcing
* With require-corp, all embedded resources need appropriate CORP headers