### PR TITLE
feat(tests): Add PHPUnit assertions for security headers and update testing documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,11 @@ load content from another domain than the page's domain.
 * **Referrer Policy**: `Referrer-Policy` header is added to all responses to control the `Referer` header
   that is added to requests made from your site, and for navigations away from your site by browsers.
 
+## Testing
+
+The bundle provides PHPUnit assertions to test security headers in your application.
+See [TESTING.md](TESTING.md) for details.
+
 ## Usage
 
 See [the documentation][2] for usage instructions.

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,0 +1,257 @@
+# Testing Security Headers
+
+The NelmioSecurityBundle provides PHPUnit constraints and a trait to help you test the security headers in your application.
+
+## Installation
+
+The test utilities are included in the bundle. You can use the `SecurityHeadersAssertionsTrait` in your functional tests.
+
+## Basic Usage
+
+The trait allows you to add security header assertions to any test case that extends `WebTestCase`:
+
+```php
+<?php
+
+use Nelmio\SecurityBundle\Test\SecurityHeadersAssertionsTrait;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\HttpFoundation\Request;
+
+class HomepageTest extends WebTestCase
+{
+    use SecurityHeadersAssertionsTrait;
+
+    public function testHomepageHasSecurityHeaders(): void
+    {
+        $client = static::createClient([], ['HTTPS' => 'on']);
+        $client->request(Request::METHOD_GET, '/');
+
+        static::assertIsIsolated();
+        static::assertFrameOptions('DENY');
+        static::assertContentTypeOptions();
+        static::assertReferrerPolicy(['no-referrer', 'strict-origin-when-cross-origin']);
+        static::assertStrictTransportSecurity();
+        static::assertCspHeader();
+    }
+}
+```
+
+## Available Assertions
+
+### Cross-Origin Isolation
+
+**`assertIsIsolated()`**
+
+Verifies that the response is properly configured for cross-origin isolation, which enables powerful browser features like `SharedArrayBuffer` and high-precision timers.
+
+```php
+static::assertIsIsolated();
+```
+
+This checks:
+- Cross-Origin-Resource-Policy: same-origin
+- Cross-Origin-Embedder-Policy: require-corp
+- Cross-Origin-Opener-Policy: same-origin
+
+### Individual Header Assertions
+
+**Cross-Origin Headers**
+
+```php
+// All cross-origin headers at once (all parameters are required)
+static::assertCrossOriginHeaders('same-origin', 'require-corp', 'same-origin');
+
+// Or individually
+static::assertCrossOriginResourcePolicy('same-origin');
+static::assertCrossOriginEmbedderPolicy('require-corp');
+static::assertCrossOriginOpenerPolicy('same-origin');
+```
+
+**Frame Options**
+
+```php
+static::assertFrameOptions('DENY');
+static::assertFrameOptions('SAMEORIGIN');
+```
+
+**Content Type Options**
+
+```php
+static::assertContentTypeOptions();
+```
+
+**Referrer Policy**
+
+```php
+static::assertReferrerPolicy(['no-referrer', 'strict-origin-when-cross-origin']);
+```
+
+**Strict Transport Security (HSTS)**
+
+```php
+// With default values (maxAge=31536000, includeSubDomains=true, preload=true)
+static::assertStrictTransportSecurity();
+
+// With custom values
+static::assertStrictTransportSecurity(31536000, true, true);
+```
+
+**Content Security Policy**
+
+```php
+// Check that CSP header exists
+static::assertCspHeader();
+
+// Check for specific directives
+static::assertCspHeader([
+    'default-src',
+    'script-src',
+    'style-src',
+]);
+
+// Check Content-Security-Policy-Report-Only instead
+static::assertCspHeader(['default-src', 'script-src'], true);
+
+// Check that CSP contains specific values
+static::assertCspHeader(null, false, ["'self'", 'https://cdn.example.com']);
+
+// Check that CSP does NOT contain unsafe values
+static::assertCspHeader(null, false, [], ["'unsafe-inline'", "'unsafe-eval'"]);
+
+// Combine all checks: directives, required values, and forbidden values
+static::assertCspHeader(
+    ['default-src', 'script-src'],  // required directives
+    false,                          // not report-only
+    ["'self'"],                     // must contain 'self'
+    ["'unsafe-inline'"]             // must NOT contain 'unsafe-inline'
+);
+```
+
+## Advanced Examples
+
+### Testing Multiple Routes
+
+```php
+/**
+ * @dataProvider routeProvider
+ */
+public function testSecurityHeadersForAllRoutes(string $route): void
+{
+    $client = static::createClient([], ['HTTPS' => 'on']);
+    $client->request('GET', $route);
+
+    static::assertIsIsolated();
+    static::assertFrameOptions('DENY');
+    static::assertContentTypeOptions();
+}
+
+public static function routeProvider(): iterable
+{
+    yield 'homepage' => ['/'];
+    yield 'about' => ['/about'];
+    yield 'contact' => ['/contact'];
+}
+```
+
+### Testing Different Configurations
+
+```php
+public function testApiEndpointHasRelaxedCORP(): void
+{
+    $client = static::createClient([], ['HTTPS' => 'on']);
+    $client->request('GET', '/api/public/data');
+
+    // API might use 'cross-origin' instead of 'same-origin'
+    static::assertCrossOriginHeaders('cross-origin', 'require-corp', 'same-origin');
+}
+```
+
+### Testing CSP Directives
+
+```php
+public function testHomepageHasCorrectCSP(): void
+{
+    $client = static::createClient([], ['HTTPS' => 'on']);
+    $client->request('GET', '/');
+
+    // Verify specific CSP directives are present
+    static::assertCspHeader([
+        'default-src',
+        'script-src',
+        'style-src',
+        'img-src',
+        'connect-src',
+        'font-src',
+    ]);
+}
+
+public function testReportOnlyCSP(): void
+{
+    $client = static::createClient([], ['HTTPS' => 'on']);
+    $client->request('GET', '/');
+
+    // Test Content-Security-Policy-Report-Only header
+    static::assertCspHeader(['default-src', 'script-src'], true);
+}
+
+public function testCspDoesNotAllowUnsafeInline(): void
+{
+    $client = static::createClient([], ['HTTPS' => 'on']);
+    $client->request('GET', '/');
+
+    // Ensure CSP does not contain unsafe values
+    static::assertCspHeader(
+        ['default-src', 'script-src'],
+        false,
+        [],
+        ["'unsafe-inline'", "'unsafe-eval'"]
+    );
+}
+
+public function testCspAllowsSpecificCdn(): void
+{
+    $client = static::createClient([], ['HTTPS' => 'on']);
+    $client->request('GET', '/');
+
+    // Ensure CSP allows a specific CDN
+    static::assertCspHeader(
+        ['script-src'],
+        false,
+        ['https://cdn.example.com']
+    );
+}
+```
+
+## Custom Constraints
+
+You can also use the constraints directly with PHPUnit's `assertThat()`:
+
+```php
+use Nelmio\SecurityBundle\Test\Constraint\ResponseHasCrossOriginResourcePolicy;
+
+$response = $client->getResponse();
+static::assertThat(
+    $response,
+    new ResponseHasCrossOriginResourcePolicy('same-origin')
+);
+```
+
+### Available Constraints
+
+All constraints are in the `Nelmio\SecurityBundle\Test\Constraint` namespace:
+
+- `ResponseHasCrossOriginResourcePolicy`
+- `ResponseHasCrossOriginEmbedderPolicy`
+- `ResponseHasCrossOriginOpenerPolicy`
+- `ResponseHasFrameOptions`
+- `ResponseHasContentTypeOptions`
+- `ResponseHasReferrerPolicy`
+- `ResponseHasStrictTransportSecurity`
+- `ResponseHasContentSecurityPolicy`
+
+## Best Practices
+
+1. **Test all public endpoints**: Ensure security headers are present on all your routes
+2. **Test different configurations**: If you have different header configurations for APIs vs frontend, test both
+3. **Use data providers**: Test multiple routes efficiently with PHPUnit data providers
+4. **Be specific**: Use individual assertions when you need precise control over expected values

--- a/src/Test/Constraint/ResponseHasContentSecurityPolicy.php
+++ b/src/Test/Constraint/ResponseHasContentSecurityPolicy.php
@@ -1,0 +1,207 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Nelmio SecurityBundle.
+ *
+ * (c) Nelmio <hello@nelm.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\SecurityBundle\Test\Constraint;
+
+use PHPUnit\Framework\Constraint\Constraint;
+use Symfony\Component\HttpFoundation\Response;
+
+final class ResponseHasContentSecurityPolicy extends Constraint
+{
+    /**
+     * @var string[]|null
+     */
+    private $requiredDirectives;
+
+    /**
+     * @var bool
+     */
+    private $reportOnly;
+
+    /**
+     * @var string[]
+     */
+    private $contains;
+
+    /**
+     * @var string[]
+     */
+    private $notContains;
+
+    /**
+     * @param string[]|null $requiredDirectives Directives that must be present (e.g., ['default-src', 'script-src'])
+     * @param bool          $reportOnly         Check Content-Security-Policy-Report-Only instead of Content-Security-Policy
+     * @param string[]      $contains           Values that must be present in the CSP (e.g., ["'self'", "https://example.com"])
+     * @param string[]      $notContains        Values that must NOT be present in the CSP (e.g., ["'unsafe-inline'", "'unsafe-eval'"])
+     */
+    public function __construct(
+        ?array $requiredDirectives = null,
+        bool $reportOnly = false,
+        array $contains = [],
+        array $notContains = []
+    ) {
+        $this->requiredDirectives = $requiredDirectives;
+        $this->reportOnly = $reportOnly;
+        $this->contains = $contains;
+        $this->notContains = $notContains;
+    }
+
+    public function toString(): string
+    {
+        $headerName = $this->reportOnly ? 'Content-Security-Policy-Report-Only' : 'Content-Security-Policy';
+        $parts = [];
+
+        if (null !== $this->requiredDirectives) {
+            $parts[] = \sprintf('directives: %s', implode(', ', $this->requiredDirectives));
+        }
+
+        if ([] !== $this->contains) {
+            $parts[] = \sprintf('containing: %s', implode(', ', $this->contains));
+        }
+
+        if ([] !== $this->notContains) {
+            $parts[] = \sprintf('not containing: %s', implode(', ', $this->notContains));
+        }
+
+        if ([] !== $parts) {
+            return \sprintf('has %s header with %s', $headerName, implode('; ', $parts));
+        }
+
+        return \sprintf('has %s header', $headerName);
+    }
+
+    /**
+     * @param mixed $other
+     */
+    protected function matches($other): bool
+    {
+        if (!$other instanceof Response) {
+            return false;
+        }
+
+        $headerName = $this->reportOnly ? 'Content-Security-Policy-Report-Only' : 'Content-Security-Policy';
+
+        if (!$other->headers->has($headerName)) {
+            return false;
+        }
+
+        $cspValue = $other->headers->get($headerName);
+
+        if (null === $cspValue || '' === $cspValue) {
+            return false;
+        }
+
+        // Check required directives
+        if (null !== $this->requiredDirectives) {
+            foreach ($this->requiredDirectives as $directive) {
+                if (false === strpos($cspValue, $directive)) {
+                    return false;
+                }
+            }
+        }
+
+        // Check values that must be present
+        foreach ($this->contains as $value) {
+            if (false === strpos($cspValue, $value)) {
+                return false;
+            }
+        }
+
+        // Check values that must NOT be present
+        foreach ($this->notContains as $value) {
+            if (false !== strpos($cspValue, $value)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @param mixed $other
+     */
+    protected function failureDescription($other): string
+    {
+        return 'the Response '.$this->toString();
+    }
+
+    /**
+     * @param mixed $other
+     */
+    protected function additionalFailureDescription($other): string
+    {
+        if (!$other instanceof Response) {
+            return 'Value is not a Response object';
+        }
+
+        $headerName = $this->reportOnly ? 'Content-Security-Policy-Report-Only' : 'Content-Security-Policy';
+
+        if (!$other->headers->has($headerName)) {
+            return \sprintf('%s header is missing', $headerName);
+        }
+
+        $cspValue = $other->headers->get($headerName);
+
+        if (null === $cspValue || '' === $cspValue) {
+            return \sprintf('%s header is empty', $headerName);
+        }
+
+        $issues = [];
+
+        // Check missing directives
+        if (null !== $this->requiredDirectives) {
+            $missingDirectives = [];
+            foreach ($this->requiredDirectives as $directive) {
+                if (false === strpos($cspValue, $directive)) {
+                    $missingDirectives[] = $directive;
+                }
+            }
+            if ([] !== $missingDirectives) {
+                $issues[] = \sprintf('missing directives: %s', implode(', ', $missingDirectives));
+            }
+        }
+
+        // Check missing values
+        $missingValues = [];
+        foreach ($this->contains as $value) {
+            if (false === strpos($cspValue, $value)) {
+                $missingValues[] = $value;
+            }
+        }
+        if ([] !== $missingValues) {
+            $issues[] = \sprintf('missing values: %s', implode(', ', $missingValues));
+        }
+
+        // Check forbidden values that are present
+        $forbiddenFound = [];
+        foreach ($this->notContains as $value) {
+            if (false !== strpos($cspValue, $value)) {
+                $forbiddenFound[] = $value;
+            }
+        }
+        if ([] !== $forbiddenFound) {
+            $issues[] = \sprintf('forbidden values found: %s', implode(', ', $forbiddenFound));
+        }
+
+        if ([] !== $issues) {
+            return \sprintf(
+                "%s has issues: %s\nActual header: %s",
+                $headerName,
+                implode('; ', $issues),
+                $cspValue
+            );
+        }
+
+        return \sprintf('%s header validation failed', $headerName);
+    }
+}

--- a/src/Test/Constraint/ResponseHasContentTypeOptions.php
+++ b/src/Test/Constraint/ResponseHasContentTypeOptions.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Nelmio SecurityBundle.
+ *
+ * (c) Nelmio <hello@nelm.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\SecurityBundle\Test\Constraint;
+
+use PHPUnit\Framework\Constraint\Constraint;
+use Symfony\Component\HttpFoundation\Response;
+
+final class ResponseHasContentTypeOptions extends Constraint
+{
+    public function toString(): string
+    {
+        return 'has X-Content-Type-Options header set to "nosniff"';
+    }
+
+    /**
+     * @param mixed $other
+     */
+    protected function matches($other): bool
+    {
+        if (!$other instanceof Response) {
+            return false;
+        }
+
+        if (!$other->headers->has('X-Content-Type-Options')) {
+            return false;
+        }
+
+        return 'nosniff' === $other->headers->get('X-Content-Type-Options');
+    }
+
+    /**
+     * @param mixed $other
+     */
+    protected function failureDescription($other): string
+    {
+        return 'the Response '.$this->toString();
+    }
+
+    /**
+     * @param mixed $other
+     */
+    protected function additionalFailureDescription($other): string
+    {
+        if (!$other instanceof Response) {
+            return 'Value is not a Response object';
+        }
+
+        if (!$other->headers->has('X-Content-Type-Options')) {
+            return 'X-Content-Type-Options header is missing';
+        }
+
+        return \sprintf(
+            'X-Content-Type-Options header is "%s" instead of "nosniff"',
+            $other->headers->get('X-Content-Type-Options')
+        );
+    }
+}

--- a/src/Test/Constraint/ResponseHasCrossOriginEmbedderPolicy.php
+++ b/src/Test/Constraint/ResponseHasCrossOriginEmbedderPolicy.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Nelmio SecurityBundle.
+ *
+ * (c) Nelmio <hello@nelm.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\SecurityBundle\Test\Constraint;
+
+use PHPUnit\Framework\Constraint\Constraint;
+use Symfony\Component\HttpFoundation\Response;
+
+final class ResponseHasCrossOriginEmbedderPolicy extends Constraint
+{
+    /**
+     * @var string
+     */
+    private $expected;
+
+    public function __construct(string $expected = 'require-corp')
+    {
+        $this->expected = $expected;
+    }
+
+    public function toString(): string
+    {
+        return \sprintf('has Cross-Origin-Embedder-Policy header set to "%s"', $this->expected);
+    }
+
+    /**
+     * @param mixed $other
+     */
+    protected function matches($other): bool
+    {
+        if (!$other instanceof Response) {
+            return false;
+        }
+
+        if (!$other->headers->has('Cross-Origin-Embedder-Policy')) {
+            return false;
+        }
+
+        return $other->headers->get('Cross-Origin-Embedder-Policy') === $this->expected;
+    }
+
+    /**
+     * @param mixed $other
+     */
+    protected function failureDescription($other): string
+    {
+        return 'the Response '.$this->toString();
+    }
+
+    /**
+     * @param mixed $other
+     */
+    protected function additionalFailureDescription($other): string
+    {
+        if (!$other instanceof Response) {
+            return 'Value is not a Response object';
+        }
+
+        if (!$other->headers->has('Cross-Origin-Embedder-Policy')) {
+            return 'Cross-Origin-Embedder-Policy header is missing';
+        }
+
+        return \sprintf(
+            'Cross-Origin-Embedder-Policy header is "%s" instead of "%s"',
+            $other->headers->get('Cross-Origin-Embedder-Policy'),
+            $this->expected
+        );
+    }
+}

--- a/src/Test/Constraint/ResponseHasCrossOriginOpenerPolicy.php
+++ b/src/Test/Constraint/ResponseHasCrossOriginOpenerPolicy.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Nelmio SecurityBundle.
+ *
+ * (c) Nelmio <hello@nelm.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\SecurityBundle\Test\Constraint;
+
+use PHPUnit\Framework\Constraint\Constraint;
+use Symfony\Component\HttpFoundation\Response;
+
+final class ResponseHasCrossOriginOpenerPolicy extends Constraint
+{
+    /**
+     * @var string
+     */
+    private $expected;
+
+    public function __construct(string $expected = 'same-origin')
+    {
+        $this->expected = $expected;
+    }
+
+    public function toString(): string
+    {
+        return \sprintf('has Cross-Origin-Opener-Policy header set to "%s"', $this->expected);
+    }
+
+    /**
+     * @param mixed $other
+     */
+    protected function matches($other): bool
+    {
+        if (!$other instanceof Response) {
+            return false;
+        }
+
+        if (!$other->headers->has('Cross-Origin-Opener-Policy')) {
+            return false;
+        }
+
+        return $other->headers->get('Cross-Origin-Opener-Policy') === $this->expected;
+    }
+
+    /**
+     * @param mixed $other
+     */
+    protected function failureDescription($other): string
+    {
+        return 'the Response '.$this->toString();
+    }
+
+    /**
+     * @param mixed $other
+     */
+    protected function additionalFailureDescription($other): string
+    {
+        if (!$other instanceof Response) {
+            return 'Value is not a Response object';
+        }
+
+        if (!$other->headers->has('Cross-Origin-Opener-Policy')) {
+            return 'Cross-Origin-Opener-Policy header is missing';
+        }
+
+        return \sprintf(
+            'Cross-Origin-Opener-Policy header is "%s" instead of "%s"',
+            $other->headers->get('Cross-Origin-Opener-Policy'),
+            $this->expected
+        );
+    }
+}

--- a/src/Test/Constraint/ResponseHasCrossOriginResourcePolicy.php
+++ b/src/Test/Constraint/ResponseHasCrossOriginResourcePolicy.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Nelmio SecurityBundle.
+ *
+ * (c) Nelmio <hello@nelm.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\SecurityBundle\Test\Constraint;
+
+use PHPUnit\Framework\Constraint\Constraint;
+use Symfony\Component\HttpFoundation\Response;
+
+final class ResponseHasCrossOriginResourcePolicy extends Constraint
+{
+    /**
+     * @var string
+     */
+    private $expected;
+
+    public function __construct(string $expected = 'same-origin')
+    {
+        $this->expected = $expected;
+    }
+
+    public function toString(): string
+    {
+        return \sprintf('has Cross-Origin-Resource-Policy header set to "%s"', $this->expected);
+    }
+
+    /**
+     * @param mixed $other
+     */
+    protected function matches($other): bool
+    {
+        if (!$other instanceof Response) {
+            return false;
+        }
+
+        if (!$other->headers->has('Cross-Origin-Resource-Policy')) {
+            return false;
+        }
+
+        return $other->headers->get('Cross-Origin-Resource-Policy') === $this->expected;
+    }
+
+    /**
+     * @param mixed $other
+     */
+    protected function failureDescription($other): string
+    {
+        return 'the Response '.$this->toString();
+    }
+
+    /**
+     * @param mixed $other
+     */
+    protected function additionalFailureDescription($other): string
+    {
+        if (!$other instanceof Response) {
+            return 'Value is not a Response object';
+        }
+
+        if (!$other->headers->has('Cross-Origin-Resource-Policy')) {
+            return 'Cross-Origin-Resource-Policy header is missing';
+        }
+
+        return \sprintf(
+            'Cross-Origin-Resource-Policy header is "%s" instead of "%s"',
+            $other->headers->get('Cross-Origin-Resource-Policy'),
+            $this->expected
+        );
+    }
+}

--- a/src/Test/Constraint/ResponseHasFrameOptions.php
+++ b/src/Test/Constraint/ResponseHasFrameOptions.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Nelmio SecurityBundle.
+ *
+ * (c) Nelmio <hello@nelm.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\SecurityBundle\Test\Constraint;
+
+use PHPUnit\Framework\Constraint\Constraint;
+use Symfony\Component\HttpFoundation\Response;
+
+final class ResponseHasFrameOptions extends Constraint
+{
+    /**
+     * @var string
+     */
+    private $expected;
+
+    public function __construct(string $expected = 'DENY')
+    {
+        $this->expected = $expected;
+    }
+
+    public function toString(): string
+    {
+        return \sprintf('has X-Frame-Options header set to "%s"', $this->expected);
+    }
+
+    /**
+     * @param mixed $other
+     */
+    protected function matches($other): bool
+    {
+        if (!$other instanceof Response) {
+            return false;
+        }
+
+        if (!$other->headers->has('X-Frame-Options')) {
+            return false;
+        }
+
+        return $other->headers->get('X-Frame-Options') === $this->expected;
+    }
+
+    /**
+     * @param mixed $other
+     */
+    protected function failureDescription($other): string
+    {
+        return 'the Response '.$this->toString();
+    }
+
+    /**
+     * @param mixed $other
+     */
+    protected function additionalFailureDescription($other): string
+    {
+        if (!$other instanceof Response) {
+            return 'Value is not a Response object';
+        }
+
+        if (!$other->headers->has('X-Frame-Options')) {
+            return 'X-Frame-Options header is missing';
+        }
+
+        return \sprintf(
+            'X-Frame-Options header is "%s" instead of "%s"',
+            $other->headers->get('X-Frame-Options'),
+            $this->expected
+        );
+    }
+}

--- a/src/Test/Constraint/ResponseHasReferrerPolicy.php
+++ b/src/Test/Constraint/ResponseHasReferrerPolicy.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Nelmio SecurityBundle.
+ *
+ * (c) Nelmio <hello@nelm.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\SecurityBundle\Test\Constraint;
+
+use PHPUnit\Framework\Constraint\Constraint;
+use Symfony\Component\HttpFoundation\Response;
+
+final class ResponseHasReferrerPolicy extends Constraint
+{
+    /**
+     * @var string[]
+     */
+    private $expected;
+
+    /**
+     * @param string[] $expected
+     */
+    public function __construct(array $expected = ['no-referrer', 'strict-origin-when-cross-origin'])
+    {
+        $this->expected = $expected;
+    }
+
+    public function toString(): string
+    {
+        return \sprintf('has Referrer-Policy header set to "%s"', implode(', ', $this->expected));
+    }
+
+    /**
+     * @param mixed $other
+     */
+    protected function matches($other): bool
+    {
+        if (!$other instanceof Response) {
+            return false;
+        }
+
+        if (!$other->headers->has('Referrer-Policy')) {
+            return false;
+        }
+
+        $expectedValue = implode(', ', $this->expected);
+
+        return $other->headers->get('Referrer-Policy') === $expectedValue;
+    }
+
+    /**
+     * @param mixed $other
+     */
+    protected function failureDescription($other): string
+    {
+        return 'the Response '.$this->toString();
+    }
+
+    /**
+     * @param mixed $other
+     */
+    protected function additionalFailureDescription($other): string
+    {
+        if (!$other instanceof Response) {
+            return 'Value is not a Response object';
+        }
+
+        if (!$other->headers->has('Referrer-Policy')) {
+            return 'Referrer-Policy header is missing';
+        }
+
+        return \sprintf(
+            'Referrer-Policy header is "%s" instead of "%s"',
+            $other->headers->get('Referrer-Policy'),
+            implode(', ', $this->expected)
+        );
+    }
+}

--- a/src/Test/Constraint/ResponseHasStrictTransportSecurity.php
+++ b/src/Test/Constraint/ResponseHasStrictTransportSecurity.php
@@ -1,0 +1,132 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Nelmio SecurityBundle.
+ *
+ * (c) Nelmio <hello@nelm.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\SecurityBundle\Test\Constraint;
+
+use PHPUnit\Framework\Constraint\Constraint;
+use Symfony\Component\HttpFoundation\Response;
+
+final class ResponseHasStrictTransportSecurity extends Constraint
+{
+    /**
+     * @var int
+     */
+    private $maxAge;
+
+    /**
+     * @var bool
+     */
+    private $includeSubDomains;
+
+    /**
+     * @var bool
+     */
+    private $preload;
+
+    public function __construct(int $maxAge = 31536000, bool $includeSubDomains = true, bool $preload = true)
+    {
+        $this->maxAge = $maxAge;
+        $this->includeSubDomains = $includeSubDomains;
+        $this->preload = $preload;
+    }
+
+    public function toString(): string
+    {
+        return 'has Strict-Transport-Security header properly configured';
+    }
+
+    /**
+     * @param mixed $other
+     */
+    protected function matches($other): bool
+    {
+        if (!$other instanceof Response) {
+            return false;
+        }
+
+        if (!$other->headers->has('Strict-Transport-Security')) {
+            return false;
+        }
+
+        $headerValue = $other->headers->get('Strict-Transport-Security');
+
+        if (null === $headerValue) {
+            return false;
+        }
+
+        // Check max-age
+        if (false === strpos($headerValue, \sprintf('max-age=%d', $this->maxAge))) {
+            return false;
+        }
+
+        // Check includeSubDomains
+        if ($this->includeSubDomains && false === strpos($headerValue, 'includeSubDomains')) {
+            return false;
+        }
+
+        // Check preload
+        if ($this->preload && false === strpos($headerValue, 'preload')) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * @param mixed $other
+     */
+    protected function failureDescription($other): string
+    {
+        return 'the Response '.$this->toString();
+    }
+
+    /**
+     * @param mixed $other
+     */
+    protected function additionalFailureDescription($other): string
+    {
+        if (!$other instanceof Response) {
+            return 'Value is not a Response object';
+        }
+
+        if (!$other->headers->has('Strict-Transport-Security')) {
+            return 'Strict-Transport-Security header is missing';
+        }
+
+        $headerValue = $other->headers->get('Strict-Transport-Security');
+
+        if (null === $headerValue) {
+            return 'Strict-Transport-Security header is empty';
+        }
+
+        $issues = [];
+
+        if (false === strpos($headerValue, \sprintf('max-age=%d', $this->maxAge))) {
+            $issues[] = \sprintf('max-age should be %d', $this->maxAge);
+        }
+
+        if ($this->includeSubDomains && false === strpos($headerValue, 'includeSubDomains')) {
+            $issues[] = 'should include includeSubDomains';
+        }
+
+        if ($this->preload && false === strpos($headerValue, 'preload')) {
+            $issues[] = 'should include preload';
+        }
+
+        return \sprintf(
+            'Strict-Transport-Security header is "%s" but %s',
+            $headerValue,
+            implode(', ', $issues)
+        );
+    }
+}

--- a/src/Test/SecurityHeadersAssertionsTrait.php
+++ b/src/Test/SecurityHeadersAssertionsTrait.php
@@ -1,0 +1,173 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Nelmio SecurityBundle.
+ *
+ * (c) Nelmio <hello@nelm.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\SecurityBundle\Test;
+
+use Nelmio\SecurityBundle\Test\Constraint\ResponseHasContentSecurityPolicy;
+use Nelmio\SecurityBundle\Test\Constraint\ResponseHasContentTypeOptions;
+use Nelmio\SecurityBundle\Test\Constraint\ResponseHasCrossOriginEmbedderPolicy;
+use Nelmio\SecurityBundle\Test\Constraint\ResponseHasCrossOriginOpenerPolicy;
+use Nelmio\SecurityBundle\Test\Constraint\ResponseHasCrossOriginResourcePolicy;
+use Nelmio\SecurityBundle\Test\Constraint\ResponseHasFrameOptions;
+use Nelmio\SecurityBundle\Test\Constraint\ResponseHasReferrerPolicy;
+use Nelmio\SecurityBundle\Test\Constraint\ResponseHasStrictTransportSecurity;
+
+/**
+ * Trait providing assertions to verify HTTP security headers.
+ *
+ * This trait can be used in any PHPUnit test case that extends WebTestCase.
+ *
+ * Usage:
+ *
+ * ```php
+ * use Nelmio\SecurityBundle\Test\SecurityHeadersAssertionsTrait;
+ * use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+ *
+ * class MyControllerTest extends WebTestCase
+ * {
+ *     use SecurityHeadersAssertionsTrait;
+ *
+ *     public function testHomepageHasSecurityHeaders(): void
+ *     {
+ *         $client = static::createClient([], ['HTTPS' => 'on']);
+ *         $client->request('GET', '/');
+ *
+ *         static::assertIsIsolated();
+ *     }
+ * }
+ * ```
+ */
+trait SecurityHeadersAssertionsTrait
+{
+    /**
+     * Assert Cross-Origin-Resource-Policy header is correctly set.
+     */
+    public static function assertCrossOriginResourcePolicy(
+        string $expected = 'same-origin',
+        string $message = ''
+    ): void {
+        self::assertThatForResponse(new ResponseHasCrossOriginResourcePolicy($expected), $message);
+    }
+
+    /**
+     * Assert Cross-Origin-Embedder-Policy header is correctly set.
+     */
+    public static function assertCrossOriginEmbedderPolicy(
+        string $expected = 'require-corp',
+        string $message = ''
+    ): void {
+        self::assertThatForResponse(new ResponseHasCrossOriginEmbedderPolicy($expected), $message);
+    }
+
+    /**
+     * Assert Cross-Origin-Opener-Policy header is correctly set.
+     */
+    public static function assertCrossOriginOpenerPolicy(
+        string $expected = 'same-origin',
+        string $message = ''
+    ): void {
+        self::assertThatForResponse(new ResponseHasCrossOriginOpenerPolicy($expected), $message);
+    }
+
+    /**
+     * Assert all Cross-Origin headers (CORP, COEP, COOP) are correctly set.
+     */
+    public static function assertCrossOriginHeaders(string $corp, string $coep, string $coop): void
+    {
+        static::assertCrossOriginResourcePolicy($corp);
+        static::assertCrossOriginEmbedderPolicy($coep);
+        static::assertCrossOriginOpenerPolicy($coop);
+    }
+
+    /**
+     * Assert the response is properly isolated for cross-origin isolation.
+     *
+     * This verifies that all three cross-origin headers are set with strict values:
+     * - Cross-Origin-Resource-Policy: same-origin
+     * - Cross-Origin-Embedder-Policy: require-corp
+     * - Cross-Origin-Opener-Policy: same-origin
+     *
+     * These headers enable powerful features like SharedArrayBuffer and high-precision timers.
+     */
+    public static function assertIsIsolated(): void
+    {
+        static::assertCrossOriginHeaders('same-origin', 'require-corp', 'same-origin');
+    }
+
+    /**
+     * Assert Content-Security-Policy header is present and optionally validate its content.
+     *
+     * @param string[]|null $requiredDirectives Directives that must be present (e.g., ['default-src', 'script-src'])
+     * @param bool          $reportOnly         Check Content-Security-Policy-Report-Only instead
+     * @param string[]      $contains           Values that must be present (e.g., ["'self'", "https://example.com"])
+     * @param string[]      $notContains        Values that must NOT be present (e.g., ["'unsafe-inline'", "'unsafe-eval'"])
+     * @param string        $message            Custom failure message
+     */
+    public static function assertCspHeader(
+        ?array $requiredDirectives = null,
+        bool $reportOnly = false,
+        array $contains = [],
+        array $notContains = [],
+        string $message = ''
+    ): void {
+        self::assertThatForResponse(
+            new ResponseHasContentSecurityPolicy($requiredDirectives, $reportOnly, $contains, $notContains),
+            $message
+        );
+    }
+
+    /**
+     * Assert X-Frame-Options header is correctly set.
+     */
+    public static function assertFrameOptions(
+        string $expected = 'DENY',
+        string $message = ''
+    ): void {
+        self::assertThatForResponse(new ResponseHasFrameOptions($expected), $message);
+    }
+
+    /**
+     * Assert X-Content-Type-Options header is set to nosniff.
+     */
+    public static function assertContentTypeOptions(string $message = ''): void
+    {
+        self::assertThatForResponse(new ResponseHasContentTypeOptions(), $message);
+    }
+
+    /**
+     * Assert Referrer-Policy header is correctly set.
+     *
+     * @param string[] $expected Expected policies (e.g., ['no-referrer', 'strict-origin-when-cross-origin'])
+     */
+    public static function assertReferrerPolicy(
+        array $expected = ['no-referrer', 'strict-origin-when-cross-origin'],
+        string $message = ''
+    ): void {
+        self::assertThatForResponse(new ResponseHasReferrerPolicy($expected), $message);
+    }
+
+    /**
+     * Assert Strict-Transport-Security header is correctly configured.
+     */
+    public static function assertStrictTransportSecurity(
+        int $maxAge = 31536000,
+        bool $includeSubDomains = true,
+        bool $preload = true,
+        string $message = ''
+    ): void {
+        self::assertThatForResponse(
+            new ResponseHasStrictTransportSecurity($maxAge, $includeSubDomains, $preload),
+            $message
+        );
+    }
+}

--- a/tests/Test/Constraint/ResponseHasContentSecurityPolicyTest.php
+++ b/tests/Test/Constraint/ResponseHasContentSecurityPolicyTest.php
@@ -1,0 +1,204 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Nelmio SecurityBundle.
+ *
+ * (c) Nelmio <hello@nelm.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\SecurityBundle\Tests\Test\Constraint;
+
+use Nelmio\SecurityBundle\Test\Constraint\ResponseHasContentSecurityPolicy;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Response;
+
+final class ResponseHasContentSecurityPolicyTest extends TestCase
+{
+    public function testMatchesWithHeader(): void
+    {
+        $response = new Response();
+        $response->headers->set('Content-Security-Policy', "default-src 'self'");
+
+        $constraint = new ResponseHasContentSecurityPolicy();
+
+        $this->assertTrue($constraint->evaluate($response, '', true));
+    }
+
+    public function testMatchesWithRequiredDirectives(): void
+    {
+        $response = new Response();
+        $response->headers->set('Content-Security-Policy', "default-src 'self'; script-src 'self'");
+
+        $constraint = new ResponseHasContentSecurityPolicy(['default-src', 'script-src']);
+
+        $this->assertTrue($constraint->evaluate($response, '', true));
+    }
+
+    public function testDoesNotMatchWithMissingDirective(): void
+    {
+        $response = new Response();
+        $response->headers->set('Content-Security-Policy', "default-src 'self'");
+
+        $constraint = new ResponseHasContentSecurityPolicy(['default-src', 'script-src']);
+
+        $this->assertFalse($constraint->evaluate($response, '', true));
+    }
+
+    public function testDoesNotMatchWithMissingHeader(): void
+    {
+        $response = new Response();
+
+        $constraint = new ResponseHasContentSecurityPolicy();
+
+        $this->assertFalse($constraint->evaluate($response, '', true));
+    }
+
+    public function testDoesNotMatchWithEmptyHeader(): void
+    {
+        $response = new Response();
+        $response->headers->set('Content-Security-Policy', '');
+
+        $constraint = new ResponseHasContentSecurityPolicy();
+
+        $this->assertFalse($constraint->evaluate($response, '', true));
+    }
+
+    public function testReportOnlyHeader(): void
+    {
+        $response = new Response();
+        $response->headers->set('Content-Security-Policy-Report-Only', "default-src 'self'");
+
+        $constraint = new ResponseHasContentSecurityPolicy(null, true);
+
+        $this->assertTrue($constraint->evaluate($response, '', true));
+    }
+
+    public function testReportOnlyWithRequiredDirectives(): void
+    {
+        $response = new Response();
+        $response->headers->set('Content-Security-Policy-Report-Only', "default-src 'self'; script-src 'self'");
+
+        $constraint = new ResponseHasContentSecurityPolicy(['default-src', 'script-src'], true);
+
+        $this->assertTrue($constraint->evaluate($response, '', true));
+    }
+
+    public function testToStringWithoutDirectives(): void
+    {
+        $constraint = new ResponseHasContentSecurityPolicy();
+
+        $this->assertSame('has Content-Security-Policy header', $constraint->toString());
+    }
+
+    public function testToStringWithDirectives(): void
+    {
+        $constraint = new ResponseHasContentSecurityPolicy(['default-src', 'script-src']);
+
+        $this->assertSame(
+            'has Content-Security-Policy header with directives: default-src, script-src',
+            $constraint->toString()
+        );
+    }
+
+    public function testToStringReportOnly(): void
+    {
+        $constraint = new ResponseHasContentSecurityPolicy(null, true);
+
+        $this->assertSame('has Content-Security-Policy-Report-Only header', $constraint->toString());
+    }
+
+    public function testContainsValue(): void
+    {
+        $response = new Response();
+        $response->headers->set('Content-Security-Policy', "default-src 'self'; script-src 'self' https://example.com");
+
+        $constraint = new ResponseHasContentSecurityPolicy(null, false, ["'self'", 'https://example.com']);
+
+        $this->assertTrue($constraint->evaluate($response, '', true));
+    }
+
+    public function testContainsValueFails(): void
+    {
+        $response = new Response();
+        $response->headers->set('Content-Security-Policy', "default-src 'self'");
+
+        $constraint = new ResponseHasContentSecurityPolicy(null, false, ['https://example.com']);
+
+        $this->assertFalse($constraint->evaluate($response, '', true));
+    }
+
+    public function testNotContainsValue(): void
+    {
+        $response = new Response();
+        $response->headers->set('Content-Security-Policy', "default-src 'self'; script-src 'self'");
+
+        $constraint = new ResponseHasContentSecurityPolicy(null, false, [], ["'unsafe-inline'", "'unsafe-eval'"]);
+
+        $this->assertTrue($constraint->evaluate($response, '', true));
+    }
+
+    public function testNotContainsValueFails(): void
+    {
+        $response = new Response();
+        $response->headers->set('Content-Security-Policy', "default-src 'self'; script-src 'self' 'unsafe-inline'");
+
+        $constraint = new ResponseHasContentSecurityPolicy(null, false, [], ["'unsafe-inline'"]);
+
+        $this->assertFalse($constraint->evaluate($response, '', true));
+    }
+
+    public function testCombinedContainsAndNotContains(): void
+    {
+        $response = new Response();
+        $response->headers->set('Content-Security-Policy', "default-src 'self'; script-src 'self' https://cdn.example.com");
+
+        $constraint = new ResponseHasContentSecurityPolicy(
+            ['default-src', 'script-src'],
+            false,
+            ["'self'", 'https://cdn.example.com'],
+            ["'unsafe-inline'", "'unsafe-eval'"]
+        );
+
+        $this->assertTrue($constraint->evaluate($response, '', true));
+    }
+
+    public function testToStringWithContains(): void
+    {
+        $constraint = new ResponseHasContentSecurityPolicy(null, false, ["'self'"]);
+
+        $this->assertSame(
+            "has Content-Security-Policy header with containing: 'self'",
+            $constraint->toString()
+        );
+    }
+
+    public function testToStringWithNotContains(): void
+    {
+        $constraint = new ResponseHasContentSecurityPolicy(null, false, [], ["'unsafe-inline'"]);
+
+        $this->assertSame(
+            "has Content-Security-Policy header with not containing: 'unsafe-inline'",
+            $constraint->toString()
+        );
+    }
+
+    public function testToStringWithAllOptions(): void
+    {
+        $constraint = new ResponseHasContentSecurityPolicy(
+            ['default-src'],
+            false,
+            ["'self'"],
+            ["'unsafe-inline'"]
+        );
+
+        $this->assertSame(
+            "has Content-Security-Policy header with directives: default-src; containing: 'self'; not containing: 'unsafe-inline'",
+            $constraint->toString()
+        );
+    }
+}

--- a/tests/Test/Constraint/ResponseHasContentTypeOptionsTest.php
+++ b/tests/Test/Constraint/ResponseHasContentTypeOptionsTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Nelmio SecurityBundle.
+ *
+ * (c) Nelmio <hello@nelm.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\SecurityBundle\Tests\Test\Constraint;
+
+use Nelmio\SecurityBundle\Test\Constraint\ResponseHasContentTypeOptions;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Response;
+
+final class ResponseHasContentTypeOptionsTest extends TestCase
+{
+    public function testMatchesWithCorrectHeader(): void
+    {
+        $response = new Response();
+        $response->headers->set('X-Content-Type-Options', 'nosniff');
+
+        $constraint = new ResponseHasContentTypeOptions();
+
+        $this->assertTrue($constraint->evaluate($response, '', true));
+    }
+
+    public function testDoesNotMatchWithDifferentValue(): void
+    {
+        $response = new Response();
+        $response->headers->set('X-Content-Type-Options', 'other');
+
+        $constraint = new ResponseHasContentTypeOptions();
+
+        $this->assertFalse($constraint->evaluate($response, '', true));
+    }
+
+    public function testDoesNotMatchWithMissingHeader(): void
+    {
+        $response = new Response();
+
+        $constraint = new ResponseHasContentTypeOptions();
+
+        $this->assertFalse($constraint->evaluate($response, '', true));
+    }
+
+    public function testToString(): void
+    {
+        $constraint = new ResponseHasContentTypeOptions();
+
+        $this->assertSame('has X-Content-Type-Options header set to "nosniff"', $constraint->toString());
+    }
+}

--- a/tests/Test/Constraint/ResponseHasCrossOriginEmbedderPolicyTest.php
+++ b/tests/Test/Constraint/ResponseHasCrossOriginEmbedderPolicyTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Nelmio SecurityBundle.
+ *
+ * (c) Nelmio <hello@nelm.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\SecurityBundle\Tests\Test\Constraint;
+
+use Nelmio\SecurityBundle\Test\Constraint\ResponseHasCrossOriginEmbedderPolicy;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Response;
+
+final class ResponseHasCrossOriginEmbedderPolicyTest extends TestCase
+{
+    public function testMatchesWithCorrectHeader(): void
+    {
+        $response = new Response();
+        $response->headers->set('Cross-Origin-Embedder-Policy', 'require-corp');
+
+        $constraint = new ResponseHasCrossOriginEmbedderPolicy('require-corp');
+
+        $this->assertTrue($constraint->evaluate($response, '', true));
+    }
+
+    public function testMatchesWithDefaultValue(): void
+    {
+        $response = new Response();
+        $response->headers->set('Cross-Origin-Embedder-Policy', 'require-corp');
+
+        $constraint = new ResponseHasCrossOriginEmbedderPolicy();
+
+        $this->assertTrue($constraint->evaluate($response, '', true));
+    }
+
+    public function testDoesNotMatchWithDifferentValue(): void
+    {
+        $response = new Response();
+        $response->headers->set('Cross-Origin-Embedder-Policy', 'unsafe-none');
+
+        $constraint = new ResponseHasCrossOriginEmbedderPolicy('require-corp');
+
+        $this->assertFalse($constraint->evaluate($response, '', true));
+    }
+
+    public function testDoesNotMatchWithMissingHeader(): void
+    {
+        $response = new Response();
+
+        $constraint = new ResponseHasCrossOriginEmbedderPolicy('require-corp');
+
+        $this->assertFalse($constraint->evaluate($response, '', true));
+    }
+
+    public function testToString(): void
+    {
+        $constraint = new ResponseHasCrossOriginEmbedderPolicy('require-corp');
+
+        $this->assertSame(
+            'has Cross-Origin-Embedder-Policy header set to "require-corp"',
+            $constraint->toString()
+        );
+    }
+
+    public function testCredentiallessValue(): void
+    {
+        $response = new Response();
+        $response->headers->set('Cross-Origin-Embedder-Policy', 'credentialless');
+
+        $constraint = new ResponseHasCrossOriginEmbedderPolicy('credentialless');
+
+        $this->assertTrue($constraint->evaluate($response, '', true));
+    }
+}

--- a/tests/Test/Constraint/ResponseHasCrossOriginOpenerPolicyTest.php
+++ b/tests/Test/Constraint/ResponseHasCrossOriginOpenerPolicyTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Nelmio SecurityBundle.
+ *
+ * (c) Nelmio <hello@nelm.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\SecurityBundle\Tests\Test\Constraint;
+
+use Nelmio\SecurityBundle\Test\Constraint\ResponseHasCrossOriginOpenerPolicy;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Response;
+
+final class ResponseHasCrossOriginOpenerPolicyTest extends TestCase
+{
+    public function testMatchesWithCorrectHeader(): void
+    {
+        $response = new Response();
+        $response->headers->set('Cross-Origin-Opener-Policy', 'same-origin');
+
+        $constraint = new ResponseHasCrossOriginOpenerPolicy('same-origin');
+
+        $this->assertTrue($constraint->evaluate($response, '', true));
+    }
+
+    public function testMatchesWithDefaultValue(): void
+    {
+        $response = new Response();
+        $response->headers->set('Cross-Origin-Opener-Policy', 'same-origin');
+
+        $constraint = new ResponseHasCrossOriginOpenerPolicy();
+
+        $this->assertTrue($constraint->evaluate($response, '', true));
+    }
+
+    public function testDoesNotMatchWithDifferentValue(): void
+    {
+        $response = new Response();
+        $response->headers->set('Cross-Origin-Opener-Policy', 'unsafe-none');
+
+        $constraint = new ResponseHasCrossOriginOpenerPolicy('same-origin');
+
+        $this->assertFalse($constraint->evaluate($response, '', true));
+    }
+
+    public function testDoesNotMatchWithMissingHeader(): void
+    {
+        $response = new Response();
+
+        $constraint = new ResponseHasCrossOriginOpenerPolicy('same-origin');
+
+        $this->assertFalse($constraint->evaluate($response, '', true));
+    }
+
+    public function testToString(): void
+    {
+        $constraint = new ResponseHasCrossOriginOpenerPolicy('same-origin');
+
+        $this->assertSame(
+            'has Cross-Origin-Opener-Policy header set to "same-origin"',
+            $constraint->toString()
+        );
+    }
+
+    public function testSameOriginAllowPopupsValue(): void
+    {
+        $response = new Response();
+        $response->headers->set('Cross-Origin-Opener-Policy', 'same-origin-allow-popups');
+
+        $constraint = new ResponseHasCrossOriginOpenerPolicy('same-origin-allow-popups');
+
+        $this->assertTrue($constraint->evaluate($response, '', true));
+    }
+
+    public function testNoopenerAllowPopupsValue(): void
+    {
+        $response = new Response();
+        $response->headers->set('Cross-Origin-Opener-Policy', 'noopener-allow-popups');
+
+        $constraint = new ResponseHasCrossOriginOpenerPolicy('noopener-allow-popups');
+
+        $this->assertTrue($constraint->evaluate($response, '', true));
+    }
+}

--- a/tests/Test/Constraint/ResponseHasCrossOriginResourcePolicyTest.php
+++ b/tests/Test/Constraint/ResponseHasCrossOriginResourcePolicyTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Nelmio SecurityBundle.
+ *
+ * (c) Nelmio <hello@nelm.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\SecurityBundle\Tests\Test\Constraint;
+
+use Nelmio\SecurityBundle\Test\Constraint\ResponseHasCrossOriginResourcePolicy;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Response;
+
+final class ResponseHasCrossOriginResourcePolicyTest extends TestCase
+{
+    public function testMatchesWithCorrectHeader(): void
+    {
+        $response = new Response();
+        $response->headers->set('Cross-Origin-Resource-Policy', 'same-origin');
+
+        $constraint = new ResponseHasCrossOriginResourcePolicy('same-origin');
+
+        $this->assertTrue($constraint->evaluate($response, '', true));
+    }
+
+    public function testMatchesWithDefaultValue(): void
+    {
+        $response = new Response();
+        $response->headers->set('Cross-Origin-Resource-Policy', 'same-origin');
+
+        $constraint = new ResponseHasCrossOriginResourcePolicy();
+
+        $this->assertTrue($constraint->evaluate($response, '', true));
+    }
+
+    public function testDoesNotMatchWithDifferentValue(): void
+    {
+        $response = new Response();
+        $response->headers->set('Cross-Origin-Resource-Policy', 'cross-origin');
+
+        $constraint = new ResponseHasCrossOriginResourcePolicy('same-origin');
+
+        $this->assertFalse($constraint->evaluate($response, '', true));
+    }
+
+    public function testDoesNotMatchWithMissingHeader(): void
+    {
+        $response = new Response();
+
+        $constraint = new ResponseHasCrossOriginResourcePolicy('same-origin');
+
+        $this->assertFalse($constraint->evaluate($response, '', true));
+    }
+
+    public function testToString(): void
+    {
+        $constraint = new ResponseHasCrossOriginResourcePolicy('same-origin');
+
+        $this->assertSame(
+            'has Cross-Origin-Resource-Policy header set to "same-origin"',
+            $constraint->toString()
+        );
+    }
+
+    public function testSameSiteValue(): void
+    {
+        $response = new Response();
+        $response->headers->set('Cross-Origin-Resource-Policy', 'same-site');
+
+        $constraint = new ResponseHasCrossOriginResourcePolicy('same-site');
+
+        $this->assertTrue($constraint->evaluate($response, '', true));
+    }
+
+    public function testCrossOriginValue(): void
+    {
+        $response = new Response();
+        $response->headers->set('Cross-Origin-Resource-Policy', 'cross-origin');
+
+        $constraint = new ResponseHasCrossOriginResourcePolicy('cross-origin');
+
+        $this->assertTrue($constraint->evaluate($response, '', true));
+    }
+}

--- a/tests/Test/Constraint/ResponseHasFrameOptionsTest.php
+++ b/tests/Test/Constraint/ResponseHasFrameOptionsTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Nelmio SecurityBundle.
+ *
+ * (c) Nelmio <hello@nelm.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\SecurityBundle\Tests\Test\Constraint;
+
+use Nelmio\SecurityBundle\Test\Constraint\ResponseHasFrameOptions;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Response;
+
+final class ResponseHasFrameOptionsTest extends TestCase
+{
+    public function testMatchesWithCorrectHeader(): void
+    {
+        $response = new Response();
+        $response->headers->set('X-Frame-Options', 'DENY');
+
+        $constraint = new ResponseHasFrameOptions('DENY');
+
+        $this->assertTrue($constraint->evaluate($response, '', true));
+    }
+
+    public function testMatchesWithDefaultValue(): void
+    {
+        $response = new Response();
+        $response->headers->set('X-Frame-Options', 'DENY');
+
+        $constraint = new ResponseHasFrameOptions();
+
+        $this->assertTrue($constraint->evaluate($response, '', true));
+    }
+
+    public function testDoesNotMatchWithDifferentValue(): void
+    {
+        $response = new Response();
+        $response->headers->set('X-Frame-Options', 'SAMEORIGIN');
+
+        $constraint = new ResponseHasFrameOptions('DENY');
+
+        $this->assertFalse($constraint->evaluate($response, '', true));
+    }
+
+    public function testDoesNotMatchWithMissingHeader(): void
+    {
+        $response = new Response();
+
+        $constraint = new ResponseHasFrameOptions('DENY');
+
+        $this->assertFalse($constraint->evaluate($response, '', true));
+    }
+
+    public function testToString(): void
+    {
+        $constraint = new ResponseHasFrameOptions('DENY');
+
+        $this->assertSame('has X-Frame-Options header set to "DENY"', $constraint->toString());
+    }
+
+    public function testSameOriginValue(): void
+    {
+        $response = new Response();
+        $response->headers->set('X-Frame-Options', 'SAMEORIGIN');
+
+        $constraint = new ResponseHasFrameOptions('SAMEORIGIN');
+
+        $this->assertTrue($constraint->evaluate($response, '', true));
+    }
+}

--- a/tests/Test/Constraint/ResponseHasReferrerPolicyTest.php
+++ b/tests/Test/Constraint/ResponseHasReferrerPolicyTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Nelmio SecurityBundle.
+ *
+ * (c) Nelmio <hello@nelm.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\SecurityBundle\Tests\Test\Constraint;
+
+use Nelmio\SecurityBundle\Test\Constraint\ResponseHasReferrerPolicy;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Response;
+
+final class ResponseHasReferrerPolicyTest extends TestCase
+{
+    public function testMatchesWithCorrectHeader(): void
+    {
+        $response = new Response();
+        $response->headers->set('Referrer-Policy', 'no-referrer, strict-origin-when-cross-origin');
+
+        $constraint = new ResponseHasReferrerPolicy(['no-referrer', 'strict-origin-when-cross-origin']);
+
+        $this->assertTrue($constraint->evaluate($response, '', true));
+    }
+
+    public function testMatchesWithDefaultValue(): void
+    {
+        $response = new Response();
+        $response->headers->set('Referrer-Policy', 'no-referrer, strict-origin-when-cross-origin');
+
+        $constraint = new ResponseHasReferrerPolicy();
+
+        $this->assertTrue($constraint->evaluate($response, '', true));
+    }
+
+    public function testDoesNotMatchWithDifferentValue(): void
+    {
+        $response = new Response();
+        $response->headers->set('Referrer-Policy', 'no-referrer');
+
+        $constraint = new ResponseHasReferrerPolicy(['no-referrer', 'strict-origin-when-cross-origin']);
+
+        $this->assertFalse($constraint->evaluate($response, '', true));
+    }
+
+    public function testDoesNotMatchWithMissingHeader(): void
+    {
+        $response = new Response();
+
+        $constraint = new ResponseHasReferrerPolicy();
+
+        $this->assertFalse($constraint->evaluate($response, '', true));
+    }
+
+    public function testToString(): void
+    {
+        $constraint = new ResponseHasReferrerPolicy(['no-referrer', 'strict-origin-when-cross-origin']);
+
+        $this->assertSame(
+            'has Referrer-Policy header set to "no-referrer, strict-origin-when-cross-origin"',
+            $constraint->toString()
+        );
+    }
+
+    public function testSinglePolicy(): void
+    {
+        $response = new Response();
+        $response->headers->set('Referrer-Policy', 'strict-origin');
+
+        $constraint = new ResponseHasReferrerPolicy(['strict-origin']);
+
+        $this->assertTrue($constraint->evaluate($response, '', true));
+    }
+}

--- a/tests/Test/Constraint/ResponseHasStrictTransportSecurityTest.php
+++ b/tests/Test/Constraint/ResponseHasStrictTransportSecurityTest.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Nelmio SecurityBundle.
+ *
+ * (c) Nelmio <hello@nelm.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\SecurityBundle\Tests\Test\Constraint;
+
+use Nelmio\SecurityBundle\Test\Constraint\ResponseHasStrictTransportSecurity;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Response;
+
+final class ResponseHasStrictTransportSecurityTest extends TestCase
+{
+    public function testMatchesWithCorrectHeader(): void
+    {
+        $response = new Response();
+        $response->headers->set('Strict-Transport-Security', 'max-age=31536000; includeSubDomains; preload');
+
+        $constraint = new ResponseHasStrictTransportSecurity();
+
+        $this->assertTrue($constraint->evaluate($response, '', true));
+    }
+
+    public function testMatchesWithCustomMaxAge(): void
+    {
+        $response = new Response();
+        $response->headers->set('Strict-Transport-Security', 'max-age=86400; includeSubDomains; preload');
+
+        $constraint = new ResponseHasStrictTransportSecurity(86400);
+
+        $this->assertTrue($constraint->evaluate($response, '', true));
+    }
+
+    public function testDoesNotMatchWithDifferentMaxAge(): void
+    {
+        $response = new Response();
+        $response->headers->set('Strict-Transport-Security', 'max-age=86400; includeSubDomains; preload');
+
+        $constraint = new ResponseHasStrictTransportSecurity(31536000);
+
+        $this->assertFalse($constraint->evaluate($response, '', true));
+    }
+
+    public function testDoesNotMatchWithMissingHeader(): void
+    {
+        $response = new Response();
+
+        $constraint = new ResponseHasStrictTransportSecurity();
+
+        $this->assertFalse($constraint->evaluate($response, '', true));
+    }
+
+    public function testDoesNotMatchWithMissingIncludeSubDomains(): void
+    {
+        $response = new Response();
+        $response->headers->set('Strict-Transport-Security', 'max-age=31536000; preload');
+
+        $constraint = new ResponseHasStrictTransportSecurity(31536000, true, true);
+
+        $this->assertFalse($constraint->evaluate($response, '', true));
+    }
+
+    public function testDoesNotMatchWithMissingPreload(): void
+    {
+        $response = new Response();
+        $response->headers->set('Strict-Transport-Security', 'max-age=31536000; includeSubDomains');
+
+        $constraint = new ResponseHasStrictTransportSecurity(31536000, true, true);
+
+        $this->assertFalse($constraint->evaluate($response, '', true));
+    }
+
+    public function testMatchesWithoutIncludeSubDomains(): void
+    {
+        $response = new Response();
+        $response->headers->set('Strict-Transport-Security', 'max-age=31536000; preload');
+
+        $constraint = new ResponseHasStrictTransportSecurity(31536000, false, true);
+
+        $this->assertTrue($constraint->evaluate($response, '', true));
+    }
+
+    public function testMatchesWithoutPreload(): void
+    {
+        $response = new Response();
+        $response->headers->set('Strict-Transport-Security', 'max-age=31536000; includeSubDomains');
+
+        $constraint = new ResponseHasStrictTransportSecurity(31536000, true, false);
+
+        $this->assertTrue($constraint->evaluate($response, '', true));
+    }
+
+    public function testMatchesMinimalHeader(): void
+    {
+        $response = new Response();
+        $response->headers->set('Strict-Transport-Security', 'max-age=31536000');
+
+        $constraint = new ResponseHasStrictTransportSecurity(31536000, false, false);
+
+        $this->assertTrue($constraint->evaluate($response, '', true));
+    }
+
+    public function testToString(): void
+    {
+        $constraint = new ResponseHasStrictTransportSecurity();
+
+        $this->assertSame('has Strict-Transport-Security header properly configured', $constraint->toString());
+    }
+}

--- a/tests/Test/SecurityHeadersAssertionsTraitTest.php
+++ b/tests/Test/SecurityHeadersAssertionsTraitTest.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Nelmio SecurityBundle.
+ *
+ * (c) Nelmio <hello@nelm.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\SecurityBundle\Tests\Test;
+
+use Nelmio\SecurityBundle\Test\SecurityHeadersAssertionsTrait;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+/**
+ * Tests for the SecurityHeadersAssertionsTrait assertion methods.
+ */
+final class SecurityHeadersAssertionsTraitTest extends WebTestCase
+{
+    use SecurityHeadersAssertionsTrait;
+
+    public function testAssertCrossOriginResourcePolicy(): void
+    {
+        $client = static::createClient();
+        $client->request('GET', '/');
+
+        // The test app config sets CORP to 'cross-origin'
+        static::assertCrossOriginResourcePolicy('cross-origin');
+    }
+
+    public function testAssertCrossOriginEmbedderPolicy(): void
+    {
+        $client = static::createClient();
+        $client->request('GET', '/');
+
+        // The test app config sets COEP to 'credentialless'
+        static::assertCrossOriginEmbedderPolicy('credentialless');
+    }
+
+    public function testAssertCrossOriginOpenerPolicy(): void
+    {
+        $client = static::createClient();
+        $client->request('GET', '/');
+
+        // The test app config sets COOP to 'same-origin'
+        static::assertCrossOriginOpenerPolicy('same-origin');
+    }
+
+    public function testAssertCrossOriginHeaders(): void
+    {
+        $client = static::createClient();
+        $client->request('GET', '/');
+
+        static::assertCrossOriginHeaders('cross-origin', 'credentialless', 'same-origin');
+    }
+
+    public function testAssertContentTypeOptions(): void
+    {
+        $client = static::createClient();
+        $client->request('GET', '/');
+
+        static::assertContentTypeOptions();
+    }
+
+    public function testAssertReferrerPolicy(): void
+    {
+        $client = static::createClient();
+        $client->request('GET', '/');
+
+        static::assertReferrerPolicy(['no-referrer', 'strict-origin-when-cross-origin']);
+    }
+
+    public function testAssertCspHeader(): void
+    {
+        $client = static::createClient();
+        $client->request('GET', '/');
+
+        static::assertCspHeader(['default-src', 'script-src']);
+    }
+
+    public function testAssertFrameOptions(): void
+    {
+        $client = static::createClient();
+        $client->request('GET', '/clickjacking/deny');
+
+        static::assertFrameOptions('DENY');
+    }
+}


### PR DESCRIPTION
This PR adds test utilities to help users verify security headers in their applications.

Example of usage:

```php
use Nelmio\SecurityBundle\Test\SecurityHeadersAssertionsTrait;
use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;

class MyTest extends WebTestCase
{
    use SecurityHeadersAssertionsTrait;

    public function testSecurityHeaders(): void
    {
        $client = static::createClient([], ['HTTPS' => 'on']);
        $client->request('GET', '/');

        static::assertIsIsolated(); // Verify cross-origin isolation (CORP, COEP, COOP)
        static::assertFrameOptions('DENY'); // Verify X-Frame-Options
        static::assertCspHeader(['default-src'], false, [], ["'unsafe-inline'"]); // Verify CSP
    }
}
```

See [TESTING.md](https://github.com/Spomky/NelmioSecurityBundle/blob/feature/test-assertions/TESTING.md) for full documentation.